### PR TITLE
Post intialization, rerun tick effects when dependencies change due to a state modification in another effect

### DIFF
--- a/test/Test/Hooks/Bug5.purs
+++ b/test/Test/Hooks/Bug5.purs
@@ -1,0 +1,95 @@
+module Test.Hooks.Bug5 where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Data.Tuple.Nested ((/\))
+import Effect.Aff (Aff)
+import Halogen as H
+import Halogen.Hooks (Hook, UseEffect, UseState)
+import Halogen.Hooks as Hooks
+import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
+import Test.Setup.Eval (evalM, initDriver, mkEval)
+import Test.Setup.Log (logShouldBe, readResult, writeLog)
+import Test.Setup.Types (EffectType(..), LogRef, TestEvent(..))
+import Test.Spec (Spec, before, describe, it)
+import Test.Spec.Assertions (fail)
+
+newtype RunTickAfterInitialEffectsHook h = LogHook (UseEffect (UseState Int (UseEffect (UseState Int (UseState Int h)))))
+
+derive instance newtypeRunTickAfterInitialEffectsHook :: Newtype (RunTickAfterInitialEffectsHook h) _
+
+rerunTickAfterInitialEffects :: LogRef -> Hook Aff RunTickAfterInitialEffectsHook { count :: Int, state1 :: Int, state2 :: Int }
+rerunTickAfterInitialEffects log = Hooks.wrap Hooks.do
+  count /\ countToken <- Hooks.useState 0
+  state1 /\ stateToken1 <- Hooks.useState 1
+  Hooks.useLifecycleEffect do
+    writeLog (RunEffect (EffectBody 0)) log
+    Hooks.modify_ stateToken1 (_ + 1)
+    pure $ Just do
+      writeLog (RunEffect (EffectCleanup 0)) log
+
+  state2 /\ stateToken2 <- Hooks.useState 0
+  useMyEffect stateToken2 { state1 }
+  Hooks.pure { count, state1, state2 }
+
+  where
+    useMyEffect stateToken2 deps@{ state1 : state1' } = Hooks.captures deps Hooks.useTickEffect do
+      writeLog (RunEffect (EffectBody 1)) log
+      Hooks.modify_ stateToken2 (_ + state1')
+      pure $ Just do
+        writeLog (RunEffect (EffectCleanup 1)) log
+
+rerunTickAfterInitialEffectsHook :: Spec Unit
+rerunTickAfterInitialEffectsHook = before initDriver $ describe "rerunTickAfterInitialEffects" do
+  let eval = mkEval rerunTickAfterInitialEffects
+
+  it "tick effect reruns when memos are updated via initial effect's state modification" \ref -> do
+    { count, state1, state2 } <- evalM ref do
+      eval H.Initialize
+      readResult ref
+
+    when (count /= 0) $ fail $ "count /= 0. count: " <> show count
+    when (state1 /= 2) $ fail $ "state1 /= 2. state1: " <> show state1
+    when (state2 /= 3) $ fail $ "state2 /= 3. state2: " <> show state2
+    logShouldBe ref initializeSteps
+
+  where
+  initializeSteps =
+    [ RunHooks Initialize         -- initialize hooks
+    , Render                      -- first render occurs
+
+    , RunEffect (EffectBody 0)    -- run enqueued lifecycle effect's initializer
+    , ModifyState                 -- state1 gets incremented to 2,
+                                  --    which should cause tick effect to rerun
+    , RunHooks Queued             -- rerun all non-effect hooks to update state
+                                  --    now the returned `state1` value is 2
+    , Render                      -- render
+
+    , RunEffect (EffectBody 1)    -- run enqueued tick effect's initializer
+    , ModifyState                 -- state2 gets incremented to 1
+                                  -- (i.e. 0 + state1's initial value: 1)
+    , RunHooks Queued             -- rerun all non-effect hooks to update state
+                                  --    now the returned `state2` value is 1
+    , Render                      -- render
+
+    , RunHooks Step               -- rerun hooks in case tick effect updated state
+    , Render
+
+    -- note: a RunHooks Step is missing here...
+
+    , RunEffect (EffectCleanup 1) -- tick effect is rerun due to lifecycle effect's
+                                  -- initializer modifying its dependencies
+    , RunEffect (EffectBody 1)
+    , ModifyState                 -- state2 gets incremented to 3
+                                  -- (i.e. 1 + state2's current value: 2)
+
+    , RunHooks Queued             -- rerun all non-effect hooks to update state
+                                  --    now the returned `state2` value is 1
+    , Render                      -- render
+
+
+    , RunHooks Step               -- rerun hooks in case tick effect updated state
+    , Render
+    ]

--- a/test/Test/Hooks/Bug5.purs
+++ b/test/Test/Hooks/Bug5.purs
@@ -77,7 +77,6 @@ rerunTickAfterInitialEffectsHook = before initDriver $ describe "rerunTickAfterI
     , RunHooks Step               -- rerun hooks in case tick effect updated state
     , Render
 
-    -- note: a RunHooks Step is missing here...
 
     , RunEffect (EffectCleanup 1) -- tick effect is rerun due to lifecycle effect's
                                   -- initializer modifying its dependencies

--- a/test/Test/Hooks/Bug5.purs
+++ b/test/Test/Hooks/Bug5.purs
@@ -75,17 +75,18 @@ rerunTickAfterInitialEffectsHook = before initDriver $ describe "rerunTickAfterI
     , Render                      -- render
 
     , RunHooks Step               -- rerun hooks in case tick effect updated state
-    , Render
+                                  --   here we enqueue but don't yet run the
+                                  --   tick effect due to the lifecycle effect's
+                                  --   initializer modifying its dependencies
+    , Render                      -- render (because we have to...)
 
-
-    , RunEffect (EffectCleanup 1) -- tick effect is rerun due to lifecycle effect's
-                                  -- initializer modifying its dependencies
-    , RunEffect (EffectBody 1)
+    , RunEffect (EffectCleanup 1) -- rerun enqueued tick effect's initializer
+    , RunEffect (EffectBody 1)    --  and finalizer in one call
     , ModifyState                 -- state2 gets incremented to 3
                                   -- (i.e. 1 + state2's current value: 2)
 
     , RunHooks Queued             -- rerun all non-effect hooks to update state
-                                  --    now the returned `state2` value is 1
+                                  --    now the returned `state2` value is 3
     , Render                      -- render
 
 

--- a/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
@@ -63,7 +63,7 @@ lifecycleEffectHook = before initDriver $ describe "useLifecycleEffect" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render, RunEffect (EffectBody 0) ]
+    [ RunHooks Initialize, Render, RunEffect (EffectBody 0), RunHooks Step, Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render, RunEffect (EffectCleanup 0) ]

--- a/test/Test/Hooks/UseEffect/UseTickEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseTickEffect.purs
@@ -9,7 +9,7 @@ import Data.Newtype (class Newtype)
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (Hook, HookM(..), UseEffect, UseState)
+import Halogen.Hooks (Hook, HookM, UseEffect, UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, initDriver, mkEval)

--- a/test/Test/Hooks/UseEffect/UseTickEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseTickEffect.purs
@@ -65,6 +65,8 @@ tickEffectHook = before initDriver $ describe "useTickEffect" do
           , Render
           , RunEffect (EffectCleanup 0)
           , RunEffect (EffectBody 0)
+          , RunHooks Step
+          , Render
           ]
       , finalizeSteps
       ]

--- a/test/Test/Hooks/UseEffect/UseTickEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseTickEffect.purs
@@ -89,7 +89,7 @@ tickEffectHook = before initDriver $ describe "useTickEffect" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render, RunEffect (EffectBody 0) ]
+    [ RunHooks Initialize, Render, RunEffect (EffectBody 0), RunHooks Step, Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render, RunEffect (EffectCleanup 0) ]

--- a/test/Test/Hooks/UseMemo.purs
+++ b/test/Test/Hooks/UseMemo.purs
@@ -120,7 +120,7 @@ memoHook = before initDriver $ describe "useMemo" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, RunMemo (CalculateMemo 1), RunMemo (CalculateMemo 2), RunMemo (CalculateMemo 3), Render ]
+    [ RunHooks Initialize, RunMemo (CalculateMemo 1), RunMemo (CalculateMemo 2), RunMemo (CalculateMemo 3), Render, RunHooks Step, Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render ]

--- a/test/Test/Hooks/UseMemo.purs
+++ b/test/Test/Hooks/UseMemo.purs
@@ -120,7 +120,7 @@ memoHook = before initDriver $ describe "useMemo" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, RunMemo (CalculateMemo 1), RunMemo (CalculateMemo 2), RunMemo (CalculateMemo 3), Render, RunHooks Step, Render ]
+    [ RunHooks Initialize, RunMemo (CalculateMemo 1), RunMemo (CalculateMemo 2), RunMemo (CalculateMemo 3), Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render ]

--- a/test/Test/Hooks/UseRef.purs
+++ b/test/Test/Hooks/UseRef.purs
@@ -68,7 +68,7 @@ refHook = before initDriver $ describe "useRef" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render ]
+    [ RunHooks Initialize, Render, RunHooks Step, Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render ]

--- a/test/Test/Hooks/UseRef.purs
+++ b/test/Test/Hooks/UseRef.purs
@@ -8,7 +8,7 @@ import Effect.Aff (Aff)
 import Effect.Ref as Ref
 import Halogen (liftEffect)
 import Halogen as H
-import Halogen.Hooks (Hook, HookM(..), UseRef)
+import Halogen.Hooks (Hook, HookM, UseRef)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, initDriver, mkEval)
@@ -68,7 +68,7 @@ refHook = before initDriver $ describe "useRef" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render, RunHooks Step, Render ]
+    [ RunHooks Initialize, Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render ]

--- a/test/Test/Hooks/UseState.purs
+++ b/test/Test/Hooks/UseState.purs
@@ -7,7 +7,7 @@ import Data.Foldable (fold)
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (Hook, HookM(..), UseState)
+import Halogen.Hooks (Hook, HookM, UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, mkEval, initDriver)
@@ -74,7 +74,7 @@ stateHook = before initDriver $ describe "useState" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render, RunHooks Step, Render ]
+    [ RunHooks Initialize, Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render ]

--- a/test/Test/Hooks/UseState.purs
+++ b/test/Test/Hooks/UseState.purs
@@ -74,7 +74,7 @@ stateHook = before initDriver $ describe "useState" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render ]
+    [ RunHooks Initialize, Render, RunHooks Step, Render ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render ]

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -4,16 +4,22 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Aff (launchAff_)
+import Test.Hooks.Bug5 (rerunTickAfterInitialEffectsHook)
 import Test.Hooks.UseEffect (effectHook)
 import Test.Hooks.UseMemo (memoHook)
 import Test.Hooks.UseRef (refHook)
 import Test.Hooks.UseState (stateHook)
+import Test.Spec (describe)
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (runSpec)
 
 main :: Effect Unit
 main = launchAff_ $ runSpec [ consoleReporter ] do
-  stateHook
-  effectHook
-  memoHook
-  refHook
+  describe "primitive tests" do
+    stateHook
+    effectHook
+    memoHook
+    refHook
+
+  describe "bug tests" do
+    rerunTickAfterInitialEffectsHook


### PR DESCRIPTION
Same as #18 but without the prior commits.

Note: these tests do not pass right now and my change will force us to update all hook evaluation event logs