### PR TITLE
Skip evaluation on referentially-equal states

### DIFF
--- a/test/Test/Setup/Types.purs
+++ b/test/Test/Setup/Types.purs
@@ -30,6 +30,8 @@ type HookM' a = HookM () Void Aff a
 
 type HalogenQ' a = H.HalogenQ (Const Void) (HookM' Unit) LogRef a
 
+type HalogenF' b a = H.HalogenF (HookState' b) (HookM' Unit) () Void Aff a
+
 type HalogenM' b a = H.HalogenM (HookState' b) (HookM' Unit) () Void Aff a
 
 type LogRef = Ref Log


### PR DESCRIPTION
Hooks use the same machinery for state updates as Halogen does, which means that calls to `get` state are just calls to `Modify` state with the identity function.

Previously this meant that hooks would be re-run on calls to get state. Just like with Halogen, calls to get state should skip any evaluation via unsafeRefEq.

This also updates the test suite to verify that calls to get state do not trigger hook evaluations, and moves calls that log `Render` events into the actual `HalogenM` evaluation. They're more reliable there as that's where the render event will actually be triggered.