### PR TITLE
Introduce tokens for component-only features (queries, slots, output)

### DIFF
--- a/examples/Example/Halogen/Basic/Button.purs
+++ b/examples/Example/Halogen/Basic/Button.purs
@@ -11,7 +11,7 @@ import Halogen.HTML.Properties as HP
 import Halogen.Hooks as Hooks
 
 component :: forall q i o m. H.Component HH.HTML q i o m
-component = Hooks.component \_ -> Hooks.do
+component = Hooks.component \_ _ -> Hooks.do
   enabled /\ enabledState <- Hooks.useState false
 
   let

--- a/examples/Example/Halogen/Components/Button.purs
+++ b/examples/Example/Halogen/Components/Button.purs
@@ -9,6 +9,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.Hooks as Hooks
+import Halogen.Hooks.Types (ComponentTokens)
 
 type Slot = H.Slot Query Message
 
@@ -16,8 +17,10 @@ data Query a = IsOn (Boolean -> a)
 
 data Message = Toggled Boolean
 
+type Tokens = ComponentTokens Query () Message
+
 component :: forall i m. H.Component HH.HTML Query i Message m
-component = Hooks.componentWithQuery \queryToken _ -> Hooks.do
+component = Hooks.component \({ queryToken, outputToken } :: Tokens) _ -> Hooks.do
   enabled /\ enabledState <- Hooks.useState false
 
   Hooks.useQuery queryToken case _ of
@@ -30,7 +33,7 @@ component = Hooks.componentWithQuery \queryToken _ -> Hooks.do
 
     handleClick = Just do
       isEnabled <- Hooks.modify enabledState not
-      Hooks.raise (Toggled isEnabled)
+      Hooks.raise outputToken (Toggled isEnabled)
 
   Hooks.pure do
     HH.button

--- a/examples/Example/Halogen/Components/Button.purs
+++ b/examples/Example/Halogen/Components/Button.purs
@@ -9,7 +9,6 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.Hooks as Hooks
-import Halogen.Hooks.Types (ComponentTokens)
 
 type Slot = H.Slot Query Message
 
@@ -17,7 +16,7 @@ data Query a = IsOn (Boolean -> a)
 
 data Message = Toggled Boolean
 
-type Tokens = ComponentTokens Query () Message
+type Tokens = Hooks.ComponentTokens Query () Message
 
 component :: forall i m. H.Component HH.HTML Query i Message m
 component = Hooks.component \({ queryToken, outputToken } :: Tokens) _ -> Hooks.do

--- a/examples/Example/Halogen/Components/Container.purs
+++ b/examples/Example/Halogen/Components/Container.purs
@@ -16,7 +16,7 @@ _button :: SProxy "button"
 _button = SProxy
 
 component :: forall q i o m. H.Component HH.HTML q i o m
-component = Hooks.component \_ -> Hooks.do
+component = Hooks.component \{ slotToken } _ -> Hooks.do
   toggleCount /\ toggleCountState <- Hooks.useState 0
   buttonStatus /\ buttonStatusState <- Hooks.useState Nothing
 
@@ -25,7 +25,7 @@ component = Hooks.component \_ -> Hooks.do
       Hooks.modify_ toggleCountState (_ + 1)
 
     handleClick = Just do
-      Hooks.put buttonStatusState =<< Hooks.query _button unit (H.request Button.IsOn)
+      Hooks.put buttonStatusState =<< Hooks.query slotToken _button unit (H.request Button.IsOn)
 
   Hooks.pure do
     HH.div_

--- a/examples/Example/Halogen/ComponentsInputs/Container.purs
+++ b/examples/Example/Halogen/ComponentsInputs/Container.purs
@@ -15,7 +15,7 @@ import Halogen.Hooks as Hooks
 _display = SProxy :: SProxy "display"
 
 component :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
-component = Hooks.component \_ -> Hooks.do
+component = Hooks.component \_ _ -> Hooks.do
   count /\ countState <- Hooks.useState 1
 
   let

--- a/examples/Example/Halogen/ComponentsInputs/Display.purs
+++ b/examples/Example/Halogen/ComponentsInputs/Display.purs
@@ -9,7 +9,7 @@ import Halogen.Hooks as Hooks
 type Input = Int
 
 component :: forall q o m. H.Component HH.HTML q Input o m
-component = Hooks.component \input -> Hooks.pure do
+component = Hooks.component \_ input -> Hooks.pure do
   HH.div_
     [ HH.text "My input value is: "
     , HH.strong_ [ HH.text $ show input ]

--- a/examples/Example/Halogen/Effects/Random.purs
+++ b/examples/Example/Halogen/Effects/Random.purs
@@ -14,7 +14,7 @@ import Halogen.Hooks as Hooks
 type State = Maybe Number
 
 component :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
-component = Hooks.component \_ -> Hooks.do
+component = Hooks.component \_ _ -> Hooks.do
   state /\ _state <- Hooks.useState Nothing
 
   let

--- a/examples/Example/Halogen/InputRef/Component.purs
+++ b/examples/Example/Halogen/InputRef/Component.purs
@@ -15,17 +15,17 @@ import Halogen.Hooks as Hooks
 import Web.HTML.HTMLElement (focus)
 
 component :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
-component = Hooks.component \_ -> Hooks.do
+component = Hooks.component \_ _ -> Hooks.do
   let
+    refLabel :: H.RefLabel
     refLabel = H.RefLabel "inputElement"
 
-    handleButtonClick :: forall slots. HookM slots o m Unit
+    handleButtonClick :: HookM m Unit
     handleButtonClick = do
       Hooks.getHTMLElementRef refLabel >>= traverse_ (focus >>> liftEffect)
 
   Hooks.pure do
-    HH.div
-      [ ]
+    HH.div_
       [ HH.input
           [ HP.type_ HP.InputText
           , HP.ref refLabel

--- a/examples/Example/Hooks/Components.purs
+++ b/examples/Example/Hooks/Components.purs
@@ -20,7 +20,7 @@ import Halogen.HTML.Events as HE
 import Halogen.Hooks as Hooks
 
 windowWidth :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
-windowWidth = Hooks.component \_ -> Hooks.do
+windowWidth = Hooks.component \_ _ -> Hooks.do
   width <- useWindowWidth
   Hooks.pure do
     HH.div_
@@ -30,7 +30,7 @@ windowWidth = Hooks.component \_ -> Hooks.do
       ]
 
 previousValue :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
-previousValue = Hooks.component \_ -> Hooks.do
+previousValue = Hooks.component \_ _ -> Hooks.do
   count /\ countState <- Hooks.useState 0
   prevCount <- usePreviousValue count
 
@@ -47,7 +47,7 @@ previousValue = Hooks.component \_ -> Hooks.do
       ]
 
 localStorage :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
-localStorage = Hooks.component \_ -> Hooks.do
+localStorage = Hooks.component \_ _ -> Hooks.do
   value /\ valueState <- useLocalStorage
     { defaultValue: 0
     , fromJson: decodeJson
@@ -77,7 +77,7 @@ localStorage = Hooks.component \_ -> Hooks.do
       ]
 
 debouncer :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
-debouncer = Hooks.component \_ -> Hooks.do
+debouncer = Hooks.component \_ _ -> Hooks.do
   text /\ textState <- Hooks.useState ""
   dbText /\ dbTextState <- Hooks.useState ""
 

--- a/examples/Example/Hooks/UseDebouncer.purs
+++ b/examples/Example/Hooks/UseDebouncer.purs
@@ -30,11 +30,11 @@ type Debouncer =
   }
 
 useDebouncer
-  :: forall slots output m a
+  :: forall m a
    . MonadAff m
   => Milliseconds
-  -> (a -> HookM slots output m Unit)
-  -> Hook slots output m (UseDebouncer a) (a -> HookM slots output m Unit)
+  -> (a -> HookM m Unit)
+  -> Hook m (UseDebouncer a) (a -> HookM m Unit)
 useDebouncer ms fn = Hooks.wrap Hooks.do
   _ /\ debounceRef <- Hooks.useRef Nothing
   _ /\ valRef <- Hooks.useRef Nothing

--- a/examples/Example/Hooks/UseInitializer.purs
+++ b/examples/Example/Hooks/UseInitializer.purs
@@ -15,9 +15,6 @@ newtype UseInitializer hooks = UseInitializer (UseEffect hooks)
 
 derive instance newtypeUseInitializer :: Newtype (UseInitializer hooks) _
 
-useInitializer
-  :: forall slots output m
-   . HookM slots output m Unit
-  -> Hook slots output m UseInitializer Unit
+useInitializer :: forall m. HookM m Unit -> Hook m UseInitializer Unit
 useInitializer initializer = Hooks.wrap do
   Hooks.useLifecycleEffect (initializer *> pure Nothing)

--- a/examples/Example/Hooks/UseLocalStorage.purs
+++ b/examples/Example/Hooks/UseLocalStorage.purs
@@ -41,11 +41,11 @@ newtype Key = Key String
 derive newtype instance eqKey :: Eq Key
 
 useLocalStorage
-  :: forall slots output m a
+  :: forall m a
    . MonadEffect m
   => Eq a
   => StorageInterface a
-  -> Hook slots output m (UseLocalStorage a) (Either String a /\ StateToken (Either String a))
+  -> Hook m (UseLocalStorage a) (Either String a /\ StateToken (Either String a))
 useLocalStorage { key, defaultValue, toJson, fromJson } = Hooks.wrap Hooks.do
   value /\ valueState <- Hooks.useState (Right defaultValue)
 

--- a/examples/Example/Hooks/UsePreviousValue.purs
+++ b/examples/Example/Hooks/UsePreviousValue.purs
@@ -15,17 +15,11 @@ import Effect.Ref as Ref
 import Halogen.Hooks (Hook, UseEffect, UseRef)
 import Halogen.Hooks as Hooks
 
-newtype UsePreviousValue a hooks =
-  UsePreviousValue (UseEffect (UseRef (Maybe a) hooks))
+newtype UsePreviousValue a hooks = UsePreviousValue (UseEffect (UseRef (Maybe a) hooks))
 
 derive instance newtypeUsePreviousValue :: Newtype (UsePreviousValue a hooks) _
 
-usePreviousValue
-  :: forall slots output m a
-   . MonadAff m
-  => Eq a
-  => a
-  -> Hook slots output m (UsePreviousValue a) (Maybe a)
+usePreviousValue :: forall m a. MonadAff m => Eq a => a -> Hook m (UsePreviousValue a) (Maybe a)
 usePreviousValue value = Hooks.wrap Hooks.do
   prev /\ ref <- Hooks.useRef Nothing
 

--- a/examples/Example/Hooks/UseWindowWidth.purs
+++ b/examples/Example/Hooks/UseWindowWidth.purs
@@ -12,9 +12,8 @@ import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Halogen as H
-import Halogen.Hooks (Hook, HookM, UseEffect, UseState)
+import Halogen.Hooks (Hook, HookM, StateToken, UseEffect, UseState)
 import Halogen.Hooks as Hooks
-import Halogen.Hooks.HookM (StateToken)
 import Halogen.Query.EventSource as ES
 import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Event (EventType(..))
@@ -27,7 +26,7 @@ newtype UseWindowWidth hooks = UseWindowWidth (UseEffect (UseState (Maybe Int) h
 
 derive instance newtypeUseWindowWidth :: Newtype (UseWindowWidth hooks) _
 
-useWindowWidth :: forall slots output m. MonadAff m => Hook slots output m UseWindowWidth (Maybe Int)
+useWindowWidth :: forall m. MonadAff m => Hook m UseWindowWidth (Maybe Int)
 useWindowWidth = Hooks.wrap Hooks.do
   width /\ widthState <- Hooks.useState Nothing
 
@@ -37,7 +36,7 @@ useWindowWidth = Hooks.wrap Hooks.do
 
   Hooks.pure width
   where
-  subscribeToWindow :: StateToken (Maybe Int) -> HookM slots output m H.SubscriptionId
+  subscribeToWindow :: StateToken (Maybe Int) -> HookM m H.SubscriptionId
   subscribeToWindow widthState = do
     let readWidth = Hooks.put widthState <<< Just <=< liftEffect <<< Window.innerWidth
 

--- a/examples/Example/Main.purs
+++ b/examples/Example/Main.purs
@@ -51,7 +51,7 @@ examples =
     ]
   where
   index :: forall q i o m. H.Component HH.HTML q i o m
-  index = Hooks.component \_ -> Hooks.pure do
+  index = Hooks.component \_ _ -> Hooks.pure do
     HH.div_
       [ HH.h1_
         [ HH.text "Halogen Hooks" ]

--- a/src/Halogen/Hooks.purs
+++ b/src/Halogen/Hooks.purs
@@ -45,11 +45,11 @@ import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Data.Tuple.Nested ((/\), type (/\))
 import Effect.Ref (Ref)
-import Halogen.Hooks.Component (component, componentWithTokens)
+import Halogen.Hooks.Component (component)
 import Halogen.Hooks.Hook (Hook, Hooked(..))
 import Halogen.Hooks.Internal.Types as IT
 import Halogen.Hooks.Internal.UseHookF (UseHookF(..))
-import Halogen.Hooks.Types (MemoValues, QueryToken, StateToken(..))
+import Halogen.Hooks.Types (ComponentTokens, MemoValues, OutputToken, QueryToken, SlotToken, StateToken(..))
 import Prelude (Unit, unit, ($), (<<<), (==))
 import Unsafe.Coerce (unsafeCoerce)
 

--- a/src/Halogen/Hooks/Component.purs
+++ b/src/Halogen/Hooks/Component.purs
@@ -19,36 +19,29 @@ import Unsafe.Coerce (unsafeCoerce)
 
 -- | Produces a Halogen component from a `Hook` which returns `ComponentHTML`.
 -- |
--- | Components that ought to receive continuous input from a parent component
--- | should be defined as a `Hook` with one argument, the `input` type. The
--- | resulting component will re-render every time new input is received.
+-- | Tokens are provided which enable access to component-only features like
+-- | queries, output messages, and child slots, which don't make sense in a pure
+-- | Hook context.
 -- |
 -- | ```purs
 -- | myComponent :: forall q i o m. H.Component q i o m
--- | myComponent = Hooks.component \input -> Hooks.do
+-- | myComponent = Hooks.component \tokens input -> Hooks.do
+-- |   ... hook implementation
+-- | ```
+-- |
+-- | If you don't need to use tokens or input, you can use underscores to throw
+-- | away those arguments.
+-- |
+-- | ```purs
+-- | myComponent :: forall q i o m. H.Component q i o m
+-- | myComponent = Hooks.component \_ _ -> Hooks.do
 -- |   ... hook implementation
 -- | ```
 component
-  :: forall hooks i m
-   . (forall ps. i -> Hooked m Unit hooks (H.ComponentHTML (HookM m Unit) ps m))
-  -> (forall q o. H.Component HH.HTML q i o m)
-component hookFn = componentWithTokens (\_ i -> hookFn i)
-
--- | Produces a Halogen component from a `Hook` which returns `ComponentHTML`,
--- | enabling the resulting component to use queries.
--- |
--- | ```purs
--- | myComponent :: forall q i o m. H.Component q i o m
--- | myComponent = Hooks.component \input queryToken -> Hooks.do
--- |   -- the query token can be used with the `useQuery hook`
--- |   Hooks.useQuery queryToken handleQuery
--- |   ... hook implementation
--- | ```
-componentWithTokens
   :: forall hooks q i ps o m
    . (ComponentTokens q ps o -> i -> Hooked m Unit hooks (H.ComponentHTML (HookM m Unit) ps m))
   -> H.Component HH.HTML q i o m
-componentWithTokens inputHookFn = do
+component inputHookFn = do
   let
     queryToken = unsafeCoerce unit :: QueryToken q
     slotToken = unsafeCoerce unit :: SlotToken ps

--- a/src/Halogen/Hooks/Hook.purs
+++ b/src/Halogen/Hooks/Hook.purs
@@ -15,15 +15,15 @@ import Halogen.Hooks.Internal.UseHookF (UseHookF)
 -- |
 -- | Functions of this type should be constructed using the Hooks API exposed
 -- | by `Halogen.Hooks`.
-type Hook ps o m (newHook :: Type -> Type) a
-  = forall hooks. Hooked ps o m hooks (newHook hooks) a
+type Hook m (newHook :: Type -> Type) a
+  = forall hooks. Hooked m hooks (newHook hooks) a
 
 -- | A largely internal type which underlies the `Hook` type. Used when the first
 -- | type variable of the indexed monad, `hooks`, cannot be hidden.
-newtype Hooked ps o m pre post a = Hooked (Indexed (Free (UseHookF ps o m)) pre post a)
+newtype Hooked m pre post a = Hooked (Indexed (Free (UseHookF m)) pre post a)
 
-derive newtype instance ixFunctorIndexed :: IxFunctor (Hooked ps o m)
-derive newtype instance ixApplyIndexed :: IxApply (Hooked ps o m)
-derive newtype instance ixApplicativeIndexed :: IxApplicative (Hooked ps o m)
-derive newtype instance ixBindIndexed :: IxBind (Hooked ps o m)
-derive newtype instance ixMonadIndexed :: IxMonad (Hooked ps o m)
+derive newtype instance ixFunctorIndexed :: IxFunctor (Hooked m)
+derive newtype instance ixApplyIndexed :: IxApply (Hooked m)
+derive newtype instance ixApplicativeIndexed :: IxApplicative (Hooked m)
+derive newtype instance ixBindIndexed :: IxBind (Hooked m)
+derive newtype instance ixMonadIndexed :: IxMonad (Hooked m)

--- a/src/Halogen/Hooks/Internal/Eval.purs
+++ b/src/Halogen/Hooks/Internal/Eval.purs
@@ -18,20 +18,21 @@ import Effect.Unsafe (unsafePerformEffect)
 import Foreign.Object as Object
 import Halogen as H
 import Halogen.Hooks.Hook (Hooked)
-import Halogen.Hooks.HookM (HookAp(..), HookF(..), HookM(..), StateToken(..))
-import Halogen.Hooks.Internal.Eval.Types (HookState, InternalHookState, InterpretHookReason(..), fromQueryFn, toQueryFn)
+import Halogen.Hooks.HookM (HookAp(..), HookF(..), HookM(..))
+import Halogen.Hooks.Internal.Eval.Types (HalogenM', InternalHookState, InterpretHookReason(..), fromQueryFn, toQueryFn)
 import Halogen.Hooks.Internal.Types (MemoValuesImpl, fromMemoValue, fromMemoValues, toQueryValue)
 import Halogen.Hooks.Internal.UseHookF (UseHookF(..))
+import Halogen.Hooks.Types (StateToken(..))
 import Partial.Unsafe (unsafePartial)
 import Unsafe.Reference (unsafeRefEq)
 
 mkEval
-  :: forall h q i ps o m b a
-   . (H.HalogenM (HookState q i ps o m b) (HookM ps o m Unit) ps o m b -> HookM ps o m ~> H.HalogenM (HookState q i ps o m b) (HookM ps o m Unit) ps o m)
-  -> (InterpretHookReason -> (i -> Hooked ps o m Unit h b) -> H.HalogenM (HookState q i ps o m b) (HookM ps o m Unit) ps o m b)
-  -> (i -> Hooked ps o m Unit h b)
-  -> H.HalogenQ q (HookM ps o m Unit) i a
-  -> H.HalogenM (HookState q i ps o m b) (HookM ps o m Unit) ps o m a
+  :: forall h q i m b a
+   . (HalogenM' q i m b b -> HookM m ~> HalogenM' q i m b)
+  -> (InterpretHookReason -> (i -> Hooked m Unit h b) -> HalogenM' q i m b b)
+  -> (i -> Hooked m Unit h b)
+  -> H.HalogenQ q (HookM m Unit) i a
+  -> HalogenM q i m b a
 mkEval runHookM runHook hookFn = case _ of
   H.Initialize a -> do
     _ <- runHookAndEffects Initialize
@@ -68,13 +69,13 @@ mkEval runHookM runHook hookFn = case _ of
     H.gets (_.result <<< unwrap)
 
 interpretHook
-  :: forall hooks q i ps o m a
-   . (H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m a -> HookM ps o m ~> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m)
-  -> (InterpretHookReason -> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m a)
+  :: forall hooks q i m a
+   . (HalogenM' q i m a a -> HookM m ~> HalogenM' q i m a)
+  -> (InterpretHookReason -> HalogenM' q i m a a)
   -> InterpretHookReason
-  -> (i -> Hooked ps o m Unit hooks a)
-  -> UseHookF ps o m
-  ~> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m
+  -> (i -> Hooked m Unit hooks a)
+  -> UseHookF m
+  ~> HalogenM' q i m a
 interpretHook runHookM runHook reason hookFn = case _ of
   UseState initial reply ->
     case reason of
@@ -103,7 +104,7 @@ interpretHook runHookM runHook reason hookFn = case _ of
     case reason of
       Initialize -> do
         let
-          handler' :: forall res. q res -> HookM ps o m (Maybe res)
+          handler' :: forall b. q b -> HookM m (Maybe b)
           handler' = handler <<< toQueryValue
 
         modifyState_ _ { queryFn = Just (toQueryFn handler') }
@@ -253,16 +254,12 @@ interpretHook runHookM runHook reason hookFn = case _ of
         modifyState_ _ { refCells { index = nextIndex } }
         pure $ reply $ Tuple value ref
 
--- Interpreter
-
 evalHookM
   :: forall q i ps o m a
-   . H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m a
-  -> HookM ps o m
-  ~> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m
+   . HalogenM' q i m a a -> HookM m ~> HalogenM' q i m a
 evalHookM runHooks (HookM evalUseHookF) = foldFree interpretHalogenHook evalUseHookF
   where
-  interpretHalogenHook :: HookF ps o m ~> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m
+  interpretHalogenHook :: HookF m ~> HalogenM' q i m a
   interpretHalogenHook = case _ of
     Modify (StateToken token) f reply -> do
       state <- getState
@@ -290,10 +287,12 @@ evalHookM runHooks (HookM evalUseHookF) = foldFree interpretHalogenHook evalUseH
     Lift f ->
       H.HalogenM $ liftF $ H.Lift f
 
-    ChildQuery box ->
+    -- TODO: Is this safe?
+    ChildQuery token box ->
       H.HalogenM $ liftF $ H.ChildQuery box
 
-    Raise o a ->
+    -- TODO: Is this safe?
+    Raise token o a ->
       H.raise o *> pure a
 
     Par (HookAp p) ->
@@ -317,36 +316,31 @@ unsafeSetCell :: forall a. Int -> a -> Array a -> Array a
 unsafeSetCell index a array = unsafePartial (fromJust (Array.modifyAt index (const a) array))
 
 -- Read the internal Hook state without incurring a `MonadEffect` constraint
-getState
-  :: forall q i ps o m a
-   . H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m (InternalHookState q i ps o m a)
+getState :: forall q i m a. HalogenM' q i m a (InternalHookState q i m a)
 getState = do
   { stateRef } <- H.gets unwrap
   pure $ unsafePerformEffect $ Ref.read stateRef
 
 -- Modify the internal Hook state without incurring a `MonadEffect` constraint
 modifyState
-  :: forall q i ps o m a
-   . (InternalHookState q i ps o m a -> InternalHookState q i ps o m a)
-  -> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m (InternalHookState q i ps o m a)
+  :: forall q i m a
+   . (InternalHookState q i m a -> InternalHookState q i m a)
+  -> HalogenM' q i m a (InternalHookState q i m a)
 modifyState fn = do
   { stateRef } <- H.gets unwrap
   pure $ unsafePerformEffect $ Ref.modify fn stateRef
 
 -- Modify the internal Hook state without incurring a `MonadEffect` constraint
 modifyState_
-  :: forall q i ps o m a
-   . (InternalHookState q i ps o m a -> InternalHookState q i ps o m a)
-  -> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m Unit
+  :: forall q i m a
+   . (InternalHookState q i m a -> InternalHookState q i m a)
+  -> HalogenM' q i m a Unit
 modifyState_ fn = do
   { stateRef } <- H.gets unwrap
   pure $ unsafePerformEffect $ Ref.modify_ fn stateRef
 
 -- Overwrite the internal Hook state without incurring a `MonadEffect` constraint
-putState
-  :: forall q i ps o m a
-   . InternalHookState q i ps o m a
-  -> H.HalogenM (HookState q i ps o m a) (HookM ps o m Unit) ps o m Unit
+putState :: forall q i m a. InternalHookState q i m a -> HalogenM' q i m a Unit
 putState s = do
   { stateRef } <- H.gets unwrap
   pure $ unsafePerformEffect $ Ref.write s stateRef

--- a/src/Halogen/Hooks/Internal/Eval/Types.purs
+++ b/src/Halogen/Hooks/Internal/Eval/Types.purs
@@ -9,10 +9,18 @@ import Effect.Ref (Ref)
 import Halogen as H
 import Halogen.Hooks.HookM (HookM)
 import Halogen.Hooks.Internal.Types (MemoValue, OutputValue, RefValue, SlotType, StateValue)
-import Halogen.Hooks.Types (MemoValues)
+import Halogen.Hooks.Types (MemoValues, OutputToken, SlotToken)
 import Unsafe.Coerce (unsafeCoerce)
 
 type HalogenM' q i m b a = H.HalogenM (HookState q i m b) (HookM m Unit) SlotType OutputValue m a
+
+toHalogenM
+  :: forall q i ps o m b a
+   . SlotToken ps
+  -> OutputToken o
+  -> HalogenM' q i m b a
+  -> H.HalogenM (HookState q i m b) (HookM m Unit) ps o m a
+toHalogenM slotToken outputToken hm = unsafeCoerce hm
 
 data InterpretHookReason
   = Initialize

--- a/src/Halogen/Hooks/Internal/Types.purs
+++ b/src/Halogen/Hooks/Internal/Types.purs
@@ -20,6 +20,16 @@ toQueryValue = unsafeCoerce
 fromQueryValue :: forall q a. QueryValue a -> q a
 fromQueryValue = unsafeCoerce
 
+foreign import data SlotType :: # Type
+
+foreign import data OutputValue :: Type
+
+toOutputValue :: forall output. output -> OutputValue
+toOutputValue = unsafeCoerce
+
+fromOutputValue :: forall output. OutputValue -> output
+fromOutputValue = unsafeCoerce
+
 foreign import data MemoValue :: Type
 
 type MemoValuesImpl =

--- a/src/Halogen/Hooks/Internal/UseHookF.purs
+++ b/src/Halogen/Hooks/Internal/UseHookF.purs
@@ -5,18 +5,18 @@ import Prelude
 import Data.Maybe (Maybe)
 import Data.Tuple.Nested (type (/\))
 import Effect.Ref (Ref)
-import Halogen.Hooks.HookM (HookM, StateToken)
-import Halogen.Hooks.Types (MemoValues, QueryToken)
+import Halogen.Hooks.HookM (HookM)
+import Halogen.Hooks.Types (MemoValues, QueryToken, StateToken)
 import Halogen.Hooks.Internal.Types (MemoValue, QueryValue, RefValue, StateValue)
 
 -- | The Hook API: a set of primitive building blocks for writing stateful logic
 -- | in Halogen. These should not be used directly; the hook functions supplied
 -- | in `Hooks` should be used instead.
-data UseHookF ps o m a
+data UseHookF m a
   = UseState StateValue ((StateValue /\ StateToken StateValue) -> a)
-  | UseEffect (Maybe MemoValues) (HookM ps o m (Maybe (HookM ps o m Unit))) a
-  | UseQuery (QueryToken QueryValue) (forall b. QueryValue b -> HookM ps o m (Maybe b)) a
+  | UseEffect (Maybe MemoValues) (HookM m (Maybe (HookM m Unit))) a
+  | UseQuery (QueryToken QueryValue) (forall b. QueryValue b -> HookM m (Maybe b)) a
   | UseMemo MemoValues (Unit -> MemoValue) (MemoValue -> a)
   | UseRef RefValue ((RefValue /\ Ref RefValue) -> a)
 
-derive instance functorUseHookF :: Functor (UseHookF ps o m)
+derive instance functorUseHookF :: Functor (UseHookF m)

--- a/src/Halogen/Hooks/Types.purs
+++ b/src/Halogen/Hooks/Types.purs
@@ -1,5 +1,17 @@
 module Halogen.Hooks.Types where
 
+type ComponentTokens q ps o =
+  { queryToken :: QueryToken q
+  , slotToken :: SlotToken ps
+  , outputToken :: OutputToken o
+  }
+
 foreign import data QueryToken :: (Type -> Type) -> Type
 
+foreign import data SlotToken :: # Type -> Type
+
+foreign import data OutputToken :: Type -> Type
+
 foreign import data MemoValues :: Type
+
+newtype StateToken state = StateToken Int

--- a/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
@@ -7,29 +7,30 @@ import Data.Foldable (fold)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Data.Tuple.Nested ((/\))
+import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (UseEffect, UseState)
+import Halogen.Hooks (Hook, HookM, UseEffect, UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, initDriver, mkEval)
 import Test.Setup.Log (logShouldBe, readResult, writeLog)
-import Test.Setup.Types (EffectType(..), Hook', HookM', LogRef, TestEvent(..))
+import Test.Setup.Types (EffectType(..), LogRef, TestEvent(..))
 import Test.Spec (Spec, before, describe, it)
 
 newtype LogHook h = LogHook (UseEffect (UseState Int h))
 
 derive instance newtypeLogHook :: Newtype (LogHook h) _
 
-useLifecycleEffectLog :: LogRef -> Hook' LogHook { tick :: HookM' Unit }
+useLifecycleEffectLog :: LogRef -> Hook Aff LogHook { tick :: HookM Aff Unit }
 useLifecycleEffectLog log = Hooks.wrap Hooks.do
   -- used to force re-evaluation of the hook; this should not re-run the effect
   -- because lifecycle effects run only once.
   count /\ countState <- Hooks.useState 0
 
   Hooks.useLifecycleEffect do
-    writeLog (RunEffect EffectBody) log
+    writeLog (RunEffect (EffectBody 0)) log
     pure $ Just do
-      writeLog (RunEffect EffectCleanup) log
+      writeLog (RunEffect (EffectCleanup 0)) log
 
   Hooks.pure { tick: Hooks.modify_ countState (_ + 1) }
 
@@ -62,7 +63,7 @@ lifecycleEffectHook = before initDriver $ describe "useLifecycleEffect" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render, RunEffect EffectBody ]
+    [ RunHooks Initialize, Render, RunEffect (EffectBody 0) ]
 
   finalizeSteps =
-    [ RunHooks Finalize, Render, RunEffect EffectCleanup ]
+    [ RunHooks Finalize, Render, RunEffect (EffectCleanup 0) ]

--- a/test/Test/Hooks/UseMemo.purs
+++ b/test/Test/Hooks/UseMemo.purs
@@ -5,13 +5,14 @@ import Prelude
 import Data.Foldable (fold)
 import Data.Newtype (class Newtype)
 import Data.Tuple.Nested ((/\))
+import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (UseMemo, UseState)
+import Halogen.Hooks (HookM(..), UseMemo, UseState, Hook)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, mkEval, initDriver)
 import Test.Setup.Log (logShouldBe, readResult, unsafeWriteLog)
-import Test.Setup.Types (Hook', HookM', LogRef, MemoType(..), TestEvent(..))
+import Test.Setup.Types (LogRef, MemoType(..), TestEvent(..))
 import Test.Spec (Spec, before, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
@@ -21,15 +22,15 @@ newtype MemoHook h =
 derive instance newtypeMemoHook :: Newtype (MemoHook h) _
 
 type MemoCount =
-  { incrementA :: HookM' Unit
-  , incrementB :: HookM' Unit
-  , incrementC :: HookM' Unit
+  { incrementA :: HookM Aff Unit
+  , incrementB :: HookM Aff Unit
+  , incrementC :: HookM Aff Unit
   , expensive1 :: Int
   , expensive2 :: Int
   , expensive3 :: Int
   }
 
-useMemoCount :: LogRef -> Hook' MemoHook MemoCount
+useMemoCount :: LogRef -> Hook Aff MemoHook MemoCount
 useMemoCount log = Hooks.wrap Hooks.do
   s1 /\ ts1 <- Hooks.useState 0
   s2 /\ ts2 <- Hooks.useState 0

--- a/test/Test/Hooks/UseRef.purs
+++ b/test/Test/Hooks/UseRef.purs
@@ -4,19 +4,20 @@ import Prelude
 
 import Data.Foldable (fold)
 import Data.Tuple.Nested ((/\))
+import Effect.Aff (Aff)
 import Effect.Ref as Ref
 import Halogen (liftEffect)
 import Halogen as H
-import Halogen.Hooks (UseRef)
+import Halogen.Hooks (Hook, HookM(..), UseRef)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, initDriver, mkEval)
 import Test.Setup.Log (logShouldBe, readResult)
-import Test.Setup.Types (Hook', HookM', LogRef, TestEvent(..))
+import Test.Setup.Types (LogRef, TestEvent(..))
 import Test.Spec (Spec, before, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
-useRefCount :: LogRef -> Hook' (UseRef Int) { increment :: HookM' Unit, count :: Int }
+useRefCount :: LogRef -> Hook Aff (UseRef Int) { increment :: HookM Aff Unit, count :: Int }
 useRefCount ref = Hooks.do
   count /\ countRef <- Hooks.useRef 0
   Hooks.pure { count, increment: liftEffect $ Ref.modify_ (_ + 1) countRef }

--- a/test/Test/Hooks/UseState.purs
+++ b/test/Test/Hooks/UseState.purs
@@ -5,23 +5,24 @@ import Prelude
 import Data.Array (replicate)
 import Data.Foldable (fold)
 import Data.Tuple.Nested ((/\))
+import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (UseState)
+import Halogen.Hooks (Hook, HookM(..), UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, mkEval, initDriver)
 import Test.Setup.Log (logShouldBe, readResult)
-import Test.Setup.Types (Hook', HookM', LogRef, TestEvent(..))
+import Test.Setup.Types (LogRef, TestEvent(..))
 import Test.Spec (Spec, before, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 
 type StateCount =
   { count :: Int
-  , increment :: HookM' Unit
-  , getState :: HookM' Int
+  , increment :: HookM Aff Unit
+  , getState :: HookM Aff Int
   }
 
-useStateCount :: LogRef -> Hook' (UseState Int) StateCount
+useStateCount :: LogRef -> Hook Aff (UseState Int) StateCount
 useStateCount ref = Hooks.do
   count /\ countState <- Hooks.useState 0
 

--- a/test/Test/Setup/Types.purs
+++ b/test/Test/Setup/Types.purs
@@ -2,7 +2,6 @@ module Test.Setup.Types where
 
 import Prelude
 
-import Data.Const (Const)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Effect.Aff (Aff)
@@ -10,29 +9,13 @@ import Effect.Ref (Ref)
 import Halogen as H
 import Halogen.Aff.Driver.State (DriverState)
 import Halogen.HTML as HH
-import Halogen.Hooks (Hook, HookF, HookM, Hooked)
+import Halogen.Hooks (HookM)
 import Halogen.Hooks.Internal.Eval.Types (HookState, InterpretHookReason)
-import Halogen.Hooks.Internal.UseHookF (UseHookF)
+import Halogen.Hooks.Internal.Types (OutputValue, SlotType)
 
-type HookState' a = HookState (Const Void) LogRef () Void Aff a
+type HalogenF' q i m b a = H.HalogenF (HookState q i m b) (HookM m Unit) SlotType OutputValue m a
 
-type DriverResultState r q a = DriverState HH.HTML r (HookState' a) q (HookM' Unit) () LogRef Void
-
-type Hooked' hookType a = Hooked () Void Aff Unit hookType a
-
-type Hook' hookType a = Hook () Void Aff hookType a
-
-type UseHookF' a = UseHookF () Void Aff a
-
-type HookF' a = HookF () Void Aff a
-
-type HookM' a = HookM () Void Aff a
-
-type HalogenQ' a = H.HalogenQ (Const Void) (HookM' Unit) LogRef a
-
-type HalogenF' b a = H.HalogenF (HookState' b) (HookM' Unit) () Void Aff a
-
-type HalogenM' b a = H.HalogenM (HookState' b) (HookM' Unit) () Void Aff a
+type DriverResultState r q a = DriverState HH.HTML r (HookState q LogRef Aff a) q (HookM Aff Unit) SlotType LogRef OutputValue
 
 type LogRef = Ref Log
 
@@ -64,7 +47,7 @@ derive instance genericHookType :: Generic HookType _
 instance showHookType :: Show HookType where
   show = genericShow
 
-data EffectType = EffectBody | EffectCleanup
+data EffectType = EffectBody Int | EffectCleanup Int
 
 derive instance eqEffectType :: Eq EffectType
 derive instance genericEffectType :: Generic EffectType _


### PR DESCRIPTION
One of the first challenges I faced implementing Hooks was what to do about queries. The request / response nature of queries make them only useful in the context of a component, not an arbitrary hook, and so I needed a way to restrict them so queries could only be used when you created a component.

@natefaubion came up with the idea of a 'token', provided by the component function, where you can only use the `useQuery` hook if you have this token via the component function. That ensures that queries are only supported in components.

As I've worked with Hooks a little longer I realize the same should have been done for output message and child slot types, too. While it's possible to _use_ functions that operate on these types within Hooks (specifically within `HookM`), they really only make sense in the context of a component, and they were always a poor fit for Hooks: if you ever specialized the output or slot type then you could only ever use the hook with a component with that specific type, which makes the hook essentially unusable for shared logic.

This pull request remedies the situation by restricting output messages and child slots (as well as functions that require them: `query`, `queryAll`, and `raise`) to only be possible when using the `component` function, via the same token mechanism as queries.

These are the consequences:

* `Hook slot output m hooks a` becomes `Hook m hooks a`
* `HookM slot output m a` becomes `HookM m a`
* `componentWithQuery` has been dropped, consolidating to a single `component` function which provides a `SlotToken`, `QueryToken`, and `OutputToken` and then accepts an input. (Having a single `component` function is important for introducing `memoComponent` later on and not having a proliferation of component constructors).
* `raise` now takes an `OutputToken` as its first argument. The compiler will verify that you provide a token which matches the type of the message you're trying to raise and the component's message type.
* `query` and `queryAll` now take a `SlotToken` as their first argument. This is also checked by the compiler against the component's slot type.
* A new `ComponentTokens` type describes the query, output, and slot type used by a component, which can be imported into user code to assist in type inference where needed.

This change implements a design that should have been in the library all along. It's also a **breaking change** that will require some simple code changes for folks using the library, so I'd like to leave this open for a few days for others to weigh in if they have anything to add.

### Testing

The tests are passing and the examples are compiling and manually tested in the browser. I also tried providing incorrect types to ensure the compiler catches you using a slot, query, or output token with a non-matching slot, query, or output type. However, I would appreciate if anyone finds a way to break this or sees an issue in the implementation.