### PR TITLE
Support skipping evaluations when input is unchanged

### DIFF
--- a/test/Test/Hooks/UseMemo.purs
+++ b/test/Test/Hooks/UseMemo.purs
@@ -7,7 +7,7 @@ import Data.Newtype (class Newtype)
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (HookM(..), UseMemo, UseState, Hook)
+import Halogen.Hooks (HookM, UseMemo, UseState, Hook)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, mkEval, initDriver)

--- a/test/Test/Setup/Eval.purs
+++ b/test/Test/Setup/Eval.purs
@@ -110,7 +110,7 @@ mkEvalQuery
    . (LogRef -> Hooked Aff Unit h b)
   -> HalogenQ q (HookM Aff Unit) LogRef a
   -> HalogenM' q LogRef Aff b a
-mkEvalQuery = Hooks.Eval.mkEval evalHookM (interpretUseHookFn evalHookM)
+mkEvalQuery = Hooks.Eval.mkEval (\_ _ -> false) evalHookM (interpretUseHookFn evalHookM)
   where
   -- WARNING: Unlike the other functions, this one needs to be manually kept in
   -- sync with the implementation in the main Hooks library. If you change this


### PR DESCRIPTION
When a Halogen component re-renders it sends input again to any of its child components. When a Hook component receives new input it will store that input and re-evaluate all Hooks.

As @natefaubion noted [in this Discourse comment](https://discourse.purescript.org/t/approaching-react-performance-with-halogen/1297/10?u=thomashoneyman), this can be a performance issue if a Hook function (especially an expensive one) is run unnecessarily each time the parent component renders.

This PR introduces `memoComponent`, a version of the `component` function which allows Hook components to ignore new input if it is unchanged from previous input.

I briefly considered adding a higher-order component to serve this purpose, but a Hook component already has the previous input in state which it can use to compare with newly-received input. I don't want to carry yet _another_ copy of input in a higher-order component unless necessary.

@natefaubion I also briefly considered using `unsafeRefEq` even when `memoComponent` is not being used, to prevent re-evaluation on unchanged input and give decent performance by default. I ultimately decided not to, to keep with how Halogen usually works, but I'm curious if you have thoughts on this.