### PR TITLE
[Take 2] Track whether an effect modifies state and only recheck tick memos if that happens

### DIFF
--- a/src/Halogen/Hooks/Component.purs
+++ b/src/Halogen/Hooks/Component.purs
@@ -122,6 +122,6 @@ memoComponent eqInput inputHookFn = do
           , memoCells: { queue: [], index: 0 }
           , refCells: { queue: [], index: 0 }
           , evalQueue: []
-          , stateModified: false
+          , stateDirty: false
           }
       }

--- a/src/Halogen/Hooks/Component.purs
+++ b/src/Halogen/Hooks/Component.purs
@@ -122,5 +122,6 @@ memoComponent eqInput inputHookFn = do
           , memoCells: { queue: [], index: 0 }
           , refCells: { queue: [], index: 0 }
           , evalQueue: []
+          , stateModified: false
           }
       }

--- a/src/Halogen/Hooks/Internal/Eval.purs
+++ b/src/Halogen/Hooks/Internal/Eval.purs
@@ -71,12 +71,12 @@ mkEval inputEq runHookM runHook hookFn = case _ of
     { evalQueue } <- getState
 
     when (not (Array.null evalQueue)) do
-      modifyState_ _ { evalQueue = [], stateModified = false }
+      modifyState_ _ { evalQueue = [], stateDirty = false }
       sequence_ evalQueue
-      { stateModified } <- getState
+      { stateDirty } <- getState
 
       let initializeOrStepReason = reason == Initialize || reason == Step
-      when (stateModified && initializeOrStepReason) do
+      when (stateDirty && initializeOrStepReason) do
         void $ runHookAndEffects Step
 
     H.gets (_.result <<< unwrap)
@@ -286,7 +286,7 @@ evalHookM runHooks (HookM evalUseHookF) = foldFree interpretHalogenHook evalUseH
         let newQueue = unsafeSetCell token next
         putState $ state
           { stateCells { queue = newQueue state.stateCells.queue }
-          , stateModified = true
+          , stateDirty = true
           }
         void runHooks
 

--- a/src/Halogen/Hooks/Internal/Eval.purs
+++ b/src/Halogen/Hooks/Internal/Eval.purs
@@ -76,7 +76,7 @@ mkEval inputEq runHookM runHook hookFn = case _ of
       { stateModified } <- getState
 
       let initializeOrStepReason = reason == Initialize || reason == Step
-      when (stateModified && initializeOrStepReason) $
+      when (stateModified && initializeOrStepReason) do
         void $ runHookAndEffects Step
 
     H.gets (_.result <<< unwrap)

--- a/src/Halogen/Hooks/Internal/Eval/Types.purs
+++ b/src/Halogen/Hooks/Internal/Eval/Types.purs
@@ -60,7 +60,7 @@ type InternalHookState q i m a =
   , effectCells :: QueueState ((Maybe MemoValues) /\ HookM m Unit)
   , memoCells :: QueueState (MemoValues /\ MemoValue)
   , refCells :: QueueState (Ref RefValue)
-  , stateModified :: Boolean
+  , stateDirty :: Boolean
   }
 
 type QueueState a =

--- a/src/Halogen/Hooks/Internal/Eval/Types.purs
+++ b/src/Halogen/Hooks/Internal/Eval/Types.purs
@@ -60,6 +60,7 @@ type InternalHookState q i m a =
   , effectCells :: QueueState ((Maybe MemoValues) /\ HookM m Unit)
   , memoCells :: QueueState (MemoValues /\ MemoValue)
   , refCells :: QueueState (Ref RefValue)
+  , stateModified :: Boolean
   }
 
 type QueueState a =

--- a/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
@@ -63,7 +63,7 @@ lifecycleEffectHook = before initDriver $ describe "useLifecycleEffect" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render, RunEffect (EffectBody 0), RunHooks Step, Render ]
+    [ RunHooks Initialize, Render, RunEffect (EffectBody 0) ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render, RunEffect (EffectCleanup 0) ]

--- a/test/Test/Hooks/UseEffect/UseTickEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseTickEffect.purs
@@ -65,8 +65,6 @@ tickEffectHook = before initDriver $ describe "useTickEffect" do
           , Render
           , RunEffect (EffectCleanup 0)
           , RunEffect (EffectBody 0)
-          , RunHooks Step
-          , Render
           ]
       , finalizeSteps
       ]
@@ -91,7 +89,7 @@ tickEffectHook = before initDriver $ describe "useTickEffect" do
 
   where
   initializeSteps =
-    [ RunHooks Initialize, Render, RunEffect (EffectBody 0), RunHooks Step, Render ]
+    [ RunHooks Initialize, Render, RunEffect (EffectBody 0) ]
 
   finalizeSteps =
     [ RunHooks Finalize, Render, RunEffect (EffectCleanup 0) ]

--- a/test/Test/Setup/Eval.purs
+++ b/test/Test/Setup/Eval.purs
@@ -146,6 +146,7 @@ initDriver = liftEffect do
     , memoCells: { queue: [], index: 0 }
     , refCells: { queue: [], index: 0 }
     , evalQueue: []
+    , stateModified: false
     }
 
   lifecycleHandlers <- Ref.new mempty

--- a/test/Test/Setup/Eval.purs
+++ b/test/Test/Setup/Eval.purs
@@ -146,7 +146,7 @@ initDriver = liftEffect do
     , memoCells: { queue: [], index: 0 }
     , refCells: { queue: [], index: 0 }
     , evalQueue: []
-    , stateModified: false
+    , stateDirty: false
     }
 
   lifecycleHandlers <- Ref.new mempty


### PR DESCRIPTION
This supersedes #27 by using Thomas' different and clearer approach to tracking whether state was modified when rerunning hooks.

The first difference between this PR and #27 is that we always set a new flag called `stateModified` to `true` when updating state. Most of the time, `stateModified` will be `true` already, but this fact removes the need for an "if ... then ... else" block in the state update. 

The second difference is how we track whether state was modified. When we have enqueued effects to run (i.e. `evalQueue` is not empty), we set the `stateModified` flag to `false` before running those effects. After running all effects via `sequence_ evalQueue`, we check whether this flag is now true. If an effect modified state, then this flag will be `true` per the first difference mentioned above.

The last difference is how I wrote the `runHooksAndEffects` code. I updated it, so that `H.gets (_.result <<< unwrap)` is always the last call, regardless of whether we need to run effects before it or not.