### PR TITLE
Return a modify function from useState instead of a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ This code replicates the Halogen basic button example which renders a count that
 
 ```purs
 myComponent = Hooks.component \_ input -> Hooks.do
-  count /\ countState <- Hooks.useState 0
+  count /\ modifyCount <- Hooks.useState 0
 
   Hooks.pure do
     HH.button
-      [ HE.onClick \_ -> Just $ Hooks.modify_ countState (_ + 1) ]
+      [ HE.onClick \_ -> Just $ modifyCount (_ + 1) ]
       [ HH.text $ show count ]
 ```
 

--- a/docs/07-Hooks-API.md
+++ b/docs/07-Hooks-API.md
@@ -26,8 +26,8 @@ Hooks.do
   let
     update :: HookM _ Unit
     update = do
-      -- Use the mody function to update the state, which will cause all hooks to
-      -- run again and a new render to occur.
+      -- Use the modify function to update the state, which will cause all hooks
+      -- to run again and a new render to occur.
       modifyCount (_ + 10)
       -- ...
 

--- a/docs/07-Hooks-API.md
+++ b/docs/07-Hooks-API.md
@@ -58,7 +58,7 @@ Hooks.do
   Hooks.useLifecycleEffect do
     -- This code will all be run after the first render, which is akin to
     -- component initialization.
-    let readWidth = Hooks.modifyWidth <<< const <<< Just <=< liftEffect <<< Window.innerWidth
+    let readWidth = modifyWidth <<< const <<< Just <=< liftEffect <<< Window.innerWidth
 
     window <- liftEffect HTML.window
     subscriptionId <- Hooks.subscribe do

--- a/docs/08-Hooks-FAQ.md
+++ b/docs/08-Hooks-FAQ.md
@@ -100,9 +100,9 @@ Hooks don't use the ordinary Halogen state functions because Hooks can have mult
 
 If you define a function in one Hooks evaluation which is going to be run during or after another Hooks evaluation, and this function refers to an `input` value or a value returned by `useState`, then the function will probably see a stale value when it runs. That's because `input` and values returned by `useState` are not mutable references; when your function runs, it will still be pointing at the value that existed when it was defined.
 
-This situation most often occurs when defining effect cleanup functions, as they will be run at the soonest the evaluation _after_ the one in which they were defined.
+This situation most often occurs when defining effect cleanup functions, as they will be run at the soonest the evaluation _after_ the one in which they were defined. However, it can also occur if you need to modify state and then use the new state afterwards to do something else.
 
-You can remedy the situation by copying the parts of state or input that your asynchronous function needs into a mutable reference. Then, the values can be read from the reference when the function runs, ensuring they are up to date. The `useGet` Hook in the [Hooks examples](../examples/Example/Hooks) offers a convenient way to do this:
+You can remedy the situation by copying the parts of state or input that your function needs into a mutable reference. Then, the values can be read from the reference when the function runs, ensuring they are up to date. The `useGet` Hook in the [Hooks examples](../examples/Example/Hooks) offers a convenient way to do this:
 
 ```purs
 myComponent :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m

--- a/examples/Example/Halogen/Basic/Button.purs
+++ b/examples/Example/Halogen/Basic/Button.purs
@@ -12,11 +12,11 @@ import Halogen.Hooks as Hooks
 
 component :: forall q i o m. H.Component HH.HTML q i o m
 component = Hooks.component \_ _ -> Hooks.do
-  enabled /\ enabledState <- Hooks.useState false
+  enabled /\ modifyEnabled <- Hooks.useState false
 
   let
     label = if enabled then "On" else "Off"
-    handleClick = Hooks.modify_ enabledState not
+    handleClick = modifyEnabled not
 
   Hooks.pure do
     HH.button

--- a/examples/Example/Halogen/Components/Button.purs
+++ b/examples/Example/Halogen/Components/Button.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
+import Effect.Class (class MonadEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -18,7 +19,7 @@ data Message = Toggled Boolean
 
 type Tokens = Hooks.ComponentTokens Query () Message
 
-component :: forall i m. H.Component HH.HTML Query i Message m
+component :: forall i m. MonadEffect m => H.Component HH.HTML Query i Message m
 component = Hooks.component \(tokens :: Tokens) _ -> Hooks.do
   enabled /\ modifyEnabled <- Hooks.useState false
 
@@ -30,8 +31,9 @@ component = Hooks.component \(tokens :: Tokens) _ -> Hooks.do
     label = if enabled then "On" else "Off"
 
     handleClick = Just do
-      modifyEnabled not
-      Hooks.raise tokens.outputToken (Toggled enabled)
+      let enabled' = not enabled
+      modifyEnabled (const enabled')
+      Hooks.raise tokens.outputToken (Toggled enabled')
 
   Hooks.pure do
     HH.button

--- a/examples/Example/Halogen/Components/Button.purs
+++ b/examples/Example/Halogen/Components/Button.purs
@@ -19,20 +19,19 @@ data Message = Toggled Boolean
 type Tokens = Hooks.ComponentTokens Query () Message
 
 component :: forall i m. H.Component HH.HTML Query i Message m
-component = Hooks.component \({ queryToken, outputToken } :: Tokens) _ -> Hooks.do
-  enabled /\ enabledState <- Hooks.useState false
+component = Hooks.component \(tokens :: Tokens) _ -> Hooks.do
+  enabled /\ modifyEnabled <- Hooks.useState false
 
-  Hooks.useQuery queryToken case _ of
+  Hooks.useQuery tokens.queryToken case _ of
     IsOn reply -> do
-      isEnabled <- Hooks.get enabledState
-      pure (Just (reply isEnabled))
+      pure (Just (reply enabled))
 
   let
     label = if enabled then "On" else "Off"
 
     handleClick = Just do
-      isEnabled <- Hooks.modify enabledState not
-      Hooks.raise outputToken (Toggled isEnabled)
+      modifyEnabled not
+      Hooks.raise tokens.outputToken (Toggled enabled)
 
   Hooks.pure do
     HH.button

--- a/examples/Example/Halogen/Components/Container.purs
+++ b/examples/Example/Halogen/Components/Container.purs
@@ -6,6 +6,7 @@ import Data.Foldable (fold)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Symbol (SProxy(..))
 import Data.Tuple.Nested ((/\))
+import Effect.Class (class MonadEffect)
 import Example.Halogen.Components.Button as Button
 import Halogen as H
 import Halogen.HTML as HH
@@ -15,14 +16,15 @@ import Halogen.Hooks as Hooks
 _button :: SProxy "button"
 _button = SProxy
 
-component :: forall q i o m. H.Component HH.HTML q i o m
+component :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
 component = Hooks.component \{ slotToken } _ -> Hooks.do
   count /\ modifyCount <- Hooks.useState 0
   buttonStatus /\ modifyButtonStatus <- Hooks.useState Nothing
 
   let
-    handleButton (Button.Toggled _) = Just do
-      modifyCount (_ + 1)
+    handleButton (Button.Toggled enabled) = Just do
+      when enabled do
+        modifyCount (_ + 1)
 
     handleClick = Just do
       status <- Hooks.query slotToken _button unit (H.request Button.IsOn)
@@ -32,7 +34,7 @@ component = Hooks.component \{ slotToken } _ -> Hooks.do
     HH.div_
       [ HH.slot _button unit Button.component unit handleButton
       , HH.p_
-          [ HH.text $ "Button has been toggled " <> show count <> " time(s)" ]
+          [ HH.text $ "Button has been toggled 'on' " <> show count <> " time(s)" ]
       , HH.p_
           [ HH.text $ fold
               [ "Last time I checked, the button was: "

--- a/examples/Example/Halogen/Components/Container.purs
+++ b/examples/Example/Halogen/Components/Container.purs
@@ -17,21 +17,22 @@ _button = SProxy
 
 component :: forall q i o m. H.Component HH.HTML q i o m
 component = Hooks.component \{ slotToken } _ -> Hooks.do
-  toggleCount /\ toggleCountState <- Hooks.useState 0
-  buttonStatus /\ buttonStatusState <- Hooks.useState Nothing
+  count /\ modifyCount <- Hooks.useState 0
+  buttonStatus /\ modifyButtonStatus <- Hooks.useState Nothing
 
   let
     handleButton (Button.Toggled _) = Just do
-      Hooks.modify_ toggleCountState (_ + 1)
+      modifyCount (_ + 1)
 
     handleClick = Just do
-      Hooks.put buttonStatusState =<< Hooks.query slotToken _button unit (H.request Button.IsOn)
+      status <- Hooks.query slotToken _button unit (H.request Button.IsOn)
+      modifyButtonStatus \_ -> status
 
   Hooks.pure do
     HH.div_
       [ HH.slot _button unit Button.component unit handleButton
       , HH.p_
-          [ HH.text $ "Button has been toggled " <> show toggleCount <> " time(s)" ]
+          [ HH.text $ "Button has been toggled " <> show count <> " time(s)" ]
       , HH.p_
           [ HH.text $ fold
               [ "Last time I checked, the button was: "

--- a/examples/Example/Halogen/ComponentsInputs/Container.purs
+++ b/examples/Example/Halogen/ComponentsInputs/Container.purs
@@ -16,11 +16,11 @@ _display = SProxy :: SProxy "display"
 
 component :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
 component = Hooks.component \_ _ -> Hooks.do
-  count /\ modifyState <- Hooks.useState 1
+  count /\ modifyCount <- Hooks.useState 1
 
   let
-    decrement = modifyState (_ - 1)
-    increment = modifyState (_ + 1)
+    decrement = modifyCount (_ - 1)
+    increment = modifyCount (_ + 1)
 
   Hooks.pure do
     HH.div_

--- a/examples/Example/Halogen/ComponentsInputs/Container.purs
+++ b/examples/Example/Halogen/ComponentsInputs/Container.purs
@@ -16,11 +16,11 @@ _display = SProxy :: SProxy "display"
 
 component :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
 component = Hooks.component \_ _ -> Hooks.do
-  count /\ countState <- Hooks.useState 1
+  count /\ modifyState <- Hooks.useState 1
 
   let
-    decrement = Hooks.modify_ countState (_ - 1)
-    increment = Hooks.modify_ countState (_ + 1)
+    decrement = modifyState (_ - 1)
+    increment = modifyState (_ + 1)
 
   Hooks.pure do
     HH.div_

--- a/examples/Example/Halogen/Effects/Random.purs
+++ b/examples/Example/Halogen/Effects/Random.purs
@@ -15,14 +15,14 @@ type State = Maybe Number
 
 component :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
 component = Hooks.component \_ _ -> Hooks.do
-  state /\ _state <- Hooks.useState Nothing
+  state /\ modifyState <- Hooks.useState Nothing
 
   let
     value = maybe "No number generated yet" show state
 
     handleClick = Just do
       newNumber <- H.liftEffect random
-      Hooks.put _state (Just newNumber)
+      modifyState \_ -> Just newNumber
 
   Hooks.pure do
     HH.div_

--- a/examples/Example/Hooks/Components.purs
+++ b/examples/Example/Hooks/Components.purs
@@ -31,24 +31,24 @@ windowWidth = Hooks.component \_ _ -> Hooks.do
 
 previousValue :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
 previousValue = Hooks.component \_ _ -> Hooks.do
-  count /\ countState <- Hooks.useState 0
-  prevCount <- usePreviousValue count
+  state /\ modifyState <- Hooks.useState 0
+  prevState <- usePreviousValue state
 
   Hooks.pure do
     HH.div
       [ ]
       [ HH.h4_ [ HH.text "Previous Value" ]
       , HH.p_ [ HH.text "This example demonstrates a hook to persist a value from the previous render." ]
-      , HH.text $ "The previous value of the state 'count' was: " <> show prevCount
+      , HH.text $ "The previous value of the state 'count' was: " <> show prevState
       , HH.br_
       , HH.button
-          [ HE.onClick \_ -> Just (Hooks.modify_ countState (_ + 1)) ]
-          [ HH.text $ "Increment (" <> show count <> ")" ]
+          [ HE.onClick \_ -> Just (modifyState (_ + 1)) ]
+          [ HH.text $ "Increment (" <> show state <> ")" ]
       ]
 
 localStorage :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
 localStorage = Hooks.component \_ _ -> Hooks.do
-  value /\ valueState <- useLocalStorage
+  state /\ modifyState <- useLocalStorage
     { defaultValue: 0
     , fromJson: decodeJson
     , toJson: encodeJson
@@ -57,10 +57,10 @@ localStorage = Hooks.component \_ _ -> Hooks.do
 
   let
     clearCount =
-      Hooks.put valueState (Right 0)
+      modifyState \_ -> Right 0
 
     increment =
-      Hooks.modify_ valueState (over _Right (_ + 1))
+      modifyState (over _Right (_ + 1))
 
   Hooks.pure do
     HH.div
@@ -70,7 +70,7 @@ localStorage = Hooks.component \_ _ -> Hooks.do
           [ HE.onClick \_ -> Just clearCount ]
           [ HH.text "Clear" ]
       , HH.br_
-      , HH.text $ "You have " <> either identity show value <> " at the intStorageExample key in local storage."
+      , HH.text $ "You have " <> either identity show state <> " at the intStorageExample key in local storage."
       , HH.button
           [ HE.onClick \_ -> Just increment ]
           [ HH.text "Increment" ]
@@ -78,15 +78,16 @@ localStorage = Hooks.component \_ _ -> Hooks.do
 
 debouncer :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
 debouncer = Hooks.component \_ _ -> Hooks.do
-  text /\ textState <- Hooks.useState ""
-  dbText /\ dbTextState <- Hooks.useState ""
+  text /\ modifyText <- Hooks.useState ""
+  debouncedText /\ modifyDebouncedText <- Hooks.useState ""
 
-  debouncedHandleInput <- useDebouncer (Milliseconds 300.0) (Hooks.put dbTextState)
+  debouncedHandleInput <-
+    useDebouncer (Milliseconds 300.0) modifyDebouncedText
 
   let
     handleInput str = Just do
-      Hooks.put textState str
-      debouncedHandleInput str
+      modifyText \_ -> str
+      debouncedHandleInput \_ -> str
 
   Hooks.pure do
     HH.div_
@@ -99,5 +100,5 @@ debouncer = Hooks.component \_ _ -> Hooks.do
       , HH.p_
           [ HH.text $ "You entered: " <> text ]
       , HH.p_
-          [ HH.text $ "You entered (debounced): " <> dbText ]
+          [ HH.text $ "You entered (debounced): " <> debouncedText ]
       ]

--- a/examples/Example/Hooks/Components.purs
+++ b/examples/Example/Hooks/Components.purs
@@ -10,7 +10,9 @@ import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (class MonadEffect)
+import Effect.Class.Console (log)
 import Example.Hooks.UseDebouncer (useDebouncer)
+import Example.Hooks.UseGet (useGet)
 import Example.Hooks.UseLocalStorage (Key(..), useLocalStorage)
 import Example.Hooks.UsePreviousValue (usePreviousValue)
 import Example.Hooks.UseWindowWidth (useWindowWidth)
@@ -27,6 +29,33 @@ windowWidth = Hooks.component \_ _ -> Hooks.do
       [ HH.h4_ [ HH.text "Window Width" ]
       , HH.p_ [ HH.text "This example demonstrates a hook which subscribes to resize events on the window and returns its width on change." ]
       , HH.text $ "Current width: " <> maybe "" show width
+      ]
+
+get :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m
+get = Hooks.component \_ _ -> Hooks.do
+  state /\ modifyState <- Hooks.useState 0
+
+  getState <- useGet state
+
+  Hooks.captures {} Hooks.useTickEffect do
+    log $ "useState in effect body: " <> show state
+    st <- getState
+    log $ "getState in effect body: " <> show st
+    pure $ Just $ do
+      log $ "useState in effect cleanup: " <> show state
+      st' <- getState
+      log $ "getState in effect cleanup: " <> show st'
+
+  Hooks.pure do
+    HH.div_
+      [ HH.h4_ [ HH.text "Get" ]
+      , HH.p_ [ HH.text "This example demonstrates a hook providing a function to keep a value in a reference so that async callbacks are always up to date." ]
+      , HH.p_ [ HH.text "For example, if you define an effect cleanup with useTickEffect or useLifecycleEffect and refer to state or input, by the time the cleanup runs the state or input will be stale. Instead, you can store the value in a reference and retrieve the current value when the cleanup runs." ]
+      , HH.p_ [ HH.text "Open the console to see the difference between useState and getState in the effect." ]
+      , HH.br_
+      , HH.button
+          [ HE.onClick \_ -> Just (modifyState (_ + 1)) ]
+          [ HH.text $ "Increment (" <> show state <> ")" ]
       ]
 
 previousValue :: forall q i o m. MonadAff m => H.Component HH.HTML q i o m

--- a/examples/Example/Hooks/UseGet.purs
+++ b/examples/Example/Hooks/UseGet.purs
@@ -1,0 +1,33 @@
+module Example.Hooks.UseGet
+  ( useGet
+  , UseGet
+  )
+  where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Data.Tuple.Nested ((/\))
+import Effect.Class (class MonadEffect, liftEffect)
+import Effect.Ref as Ref
+import Halogen.Hooks (Hook, HookM, UseEffect, UseRef)
+import Halogen.Hooks as Hooks
+
+newtype UseGet a hooks = UseGet (UseEffect (UseRef a hooks))
+
+derive instance newtypeUseGet :: Newtype (UseGet a hooks) _
+
+useGet
+  :: forall m a
+   . MonadEffect m
+  => a
+  -> Hook m (UseGet a) (HookM m a)
+useGet latest = Hooks.wrap Hooks.do
+  _ /\ ref <- Hooks.useRef latest
+
+  Hooks.captures {} Hooks.useTickEffect do
+    liftEffect $ Ref.write latest ref
+    pure Nothing
+
+  Hooks.pure (liftEffect $ Ref.read ref)

--- a/examples/Example/Main.purs
+++ b/examples/Example/Main.purs
@@ -37,6 +37,7 @@ examples =
     , "Hooks|usePreviousValue" /\ HookComponents.previousValue
     , "Hooks|useLocalStorage" /\ HookComponents.localStorage
     , "Hooks|useDebouncer" /\ HookComponents.debouncer
+    , "Hooks|useGet" /\ HookComponents.get
 
     -- Examples from the existing Halogen documentation
     , "Halogen|Basic" /\ Halogen.Basic.component

--- a/src/Halogen/Hooks.purs
+++ b/src/Halogen/Hooks.purs
@@ -43,6 +43,7 @@ import Data.Eq (class Eq)
 import Data.Indexed (Indexed(..))
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
+import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\), type (/\))
 import Effect.Ref (Ref)
 import Halogen.Hooks.Component (component)
@@ -60,23 +61,25 @@ foreign import data UseState :: Type -> Type -> Type
 -- | ```purs
 -- | Hooks.do
 -- |   -- Create a new state with `useState`
--- |   stateA /\ stateToken <- Hooks.useState initialState
--- |   intState /\ intStateToken <- Hooks.useState 0
+-- |   state /\ modifyState <- Hooks.useState 0
 -- |
--- |   -- Perform state updates in `HookM` using the state token
+-- |   -- Perform state updates in `HookM` with the `modifyState` function
 -- |   let
--- |     update newState = do
--- |       Hooks.put stateTokenA stateA
--- |       Hooks.modify_ stateTokenB (_ + 10)
+-- |     update :: HookM m Unit
+-- |     update =
+-- |       modifyState \st -> st + 10
 -- | ```
-useState :: forall state m. state -> Hook m (UseState state) (state /\ StateToken state)
+useState :: forall state m. state -> Hook m (UseState state) (state /\ ((state -> state) -> HookM m Unit))
 useState initialState = Hooked $ Indexed $ liftF $ UseState initialState' interface
   where
   initialState' :: IT.StateValue
   initialState' = IT.toStateValue initialState
 
-  interface :: IT.StateValue /\ StateToken IT.StateValue -> state /\ StateToken state
-  interface (value /\ token) = IT.fromStateValue value /\ unsafeCoerce token
+  interface
+    :: Tuple IT.StateValue ((IT.StateValue -> IT.StateValue) -> HookM m Unit)
+    -> Tuple state ((state -> state) -> HookM m Unit)
+  interface (Tuple value f) =
+    IT.fromStateValue value /\ f <<< (\fn -> IT.toStateValue <<< fn <<< IT.fromStateValue)
 
 foreign import data UseEffect :: Type -> Type
 

--- a/src/Halogen/Hooks.purs
+++ b/src/Halogen/Hooks.purs
@@ -50,7 +50,7 @@ import Halogen.Hooks.Component (component)
 import Halogen.Hooks.Hook (Hook, Hooked(..))
 import Halogen.Hooks.Internal.Types as IT
 import Halogen.Hooks.Internal.UseHookF (UseHookF(..))
-import Halogen.Hooks.Types (ComponentTokens, MemoValues, OutputToken, QueryToken, SlotToken, StateToken(..))
+import Halogen.Hooks.Types (ComponentTokens, MemoValues, OutputToken, QueryToken, SlotToken)
 import Prelude (Unit, unit, ($), (<<<), (==))
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -69,7 +69,10 @@ foreign import data UseState :: Type -> Type -> Type
 -- |     update =
 -- |       modifyState \st -> st + 10
 -- | ```
-useState :: forall state m. state -> Hook m (UseState state) (state /\ ((state -> state) -> HookM m Unit))
+useState
+  :: forall state m
+   . state
+  -> Hook m (UseState state) (state /\ ((state -> state) -> HookM m Unit))
 useState initialState = Hooked $ Indexed $ liftF $ UseState initialState' interface
   where
   initialState' :: IT.StateValue

--- a/src/Halogen/Hooks/HookM.purs
+++ b/src/Halogen/Hooks/HookM.purs
@@ -1,11 +1,8 @@
 -- | A replacement for `Halogen.Query.HalogenM` which supports a near-identical
--- | API, but adjusted for compatibility with hooks. All functions typically
+-- | API, but adjusted for compatibility with hooks. Most functions typically
 -- | available in `HalogenM` are still available here, but some have modified
--- | behavior (for example, the state functions `get`, `put`, and `modify` require
--- | an additional `StateToken` argument when used in Hooks).
--- |
--- | If you need to use a function usually available in HalogenM which is not
--- | available here, please file an issue.
+-- | behavior (for example, the state functions `get`, `put`, and `modify` don't
+-- | exist; instead, the `useState` hook returns a `modify` function you can use).
 module Halogen.Hooks.HookM where
 
 import Prelude
@@ -38,7 +35,7 @@ import Web.DOM as DOM
 import Web.HTML as HTML
 import Web.HTML.HTMLElement as HTMLElement
 
--- | A DSL fully compatible with HalogenM which is used to write effectful code
+-- | A DSL compatible with HalogenM which is used to write effectful code
 -- | for Hooks.
 data HookF m a
   = Modify (StateToken StateValue) (StateValue -> StateValue) a
@@ -54,9 +51,9 @@ data HookF m a
 
 derive instance functorHookF :: Functor m => Functor (HookF m)
 
--- | The Hook effect monad, used to write effectful code in Hooks functions. This
--- | monad is fully compatible with `HalogenM`, meaning all functions available for
--- | `HalogenM` are available in `HookM`.
+-- | The Hook effect monad, used to write effectful code in Hooks functions.
+-- | This monad is fully compatible with `HalogenM`. meaning all functionality
+-- | available for `HalogenM` is available in `HookM`.
 newtype HookM m a = HookM (Free (HookF m) a)
 
 derive newtype instance functorHookM :: Functor (HookM m)

--- a/src/Halogen/Hooks/Internal/Eval.purs
+++ b/src/Halogen/Hooks/Internal/Eval.purs
@@ -112,18 +112,13 @@ interpretHook runHookM runHook reason hookFn = case _ of
         modifyState_ _ { stateCells { index = nextIndex } }
         pure $ reply $ Tuple value (modifyWithToken token)
 
-  UseQuery _ handler a ->
-    case reason of
-      Initialize -> do
-        let
-          handler' :: forall b. q b -> HookM m (Maybe b)
-          handler' = handler <<< toQueryValue
+  UseQuery _ handler a -> do
+    let
+      handler' :: forall b. q b -> HookM m (Maybe b)
+      handler' = handler <<< toQueryValue
 
-        modifyState_ _ { queryFn = Just (toQueryFn handler') }
-        pure a
-
-      _ ->
-        pure a
+    modifyState_ _ { queryFn = Just (toQueryFn handler') }
+    pure a
 
   UseEffect mbMemos act a -> do
     case reason of

--- a/src/Halogen/Hooks/Internal/Types.purs
+++ b/src/Halogen/Hooks/Internal/Types.purs
@@ -4,6 +4,8 @@ import Halogen.Hooks.Types
 import Foreign.Object (Object)
 import Unsafe.Coerce (unsafeCoerce)
 
+newtype StateToken state = StateToken Int
+
 foreign import data StateValue :: Type
 
 toStateValue :: forall state. state -> StateValue

--- a/src/Halogen/Hooks/Internal/UseHookF.purs
+++ b/src/Halogen/Hooks/Internal/UseHookF.purs
@@ -6,14 +6,14 @@ import Data.Maybe (Maybe)
 import Data.Tuple.Nested (type (/\))
 import Effect.Ref (Ref)
 import Halogen.Hooks.HookM (HookM)
-import Halogen.Hooks.Types (MemoValues, QueryToken, StateToken)
+import Halogen.Hooks.Types (MemoValues, QueryToken)
 import Halogen.Hooks.Internal.Types (MemoValue, QueryValue, RefValue, StateValue)
 
 -- | The Hook API: a set of primitive building blocks for writing stateful logic
 -- | in Halogen. These should not be used directly; the hook functions supplied
 -- | in `Hooks` should be used instead.
 data UseHookF m a
-  = UseState StateValue ((StateValue /\ StateToken StateValue) -> a)
+  = UseState StateValue (StateValue /\ ((StateValue -> StateValue) -> HookM m Unit) -> a)
   | UseEffect (Maybe MemoValues) (HookM m (Maybe (HookM m Unit))) a
   | UseQuery (QueryToken QueryValue) (forall b. QueryValue b -> HookM m (Maybe b)) a
   | UseMemo MemoValues (Unit -> MemoValue) (MemoValue -> a)

--- a/src/Halogen/Hooks/Types.purs
+++ b/src/Halogen/Hooks/Types.purs
@@ -43,9 +43,4 @@ foreign import data OutputToken :: Type -> Type
 -- | This type is provided by the `captures` and `capturesWith` functions.
 foreign import data MemoValues :: Type
 
--- | A token which carries the type of state maintained by a particular `useState`
--- | Hook. Halogen components can have only one state, but Hooks can have many;
--- | this token serves to disambiguate multiple states internally.
--- |
--- | This token is provided by the `useState` function.
 newtype StateToken state = StateToken Int

--- a/src/Halogen/Hooks/Types.purs
+++ b/src/Halogen/Hooks/Types.purs
@@ -42,5 +42,3 @@ foreign import data OutputToken :: Type -> Type
 -- |
 -- | This type is provided by the `captures` and `capturesWith` functions.
 foreign import data MemoValues :: Type
-
-newtype StateToken state = StateToken Int

--- a/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseLifecycleEffect.purs
@@ -25,14 +25,14 @@ useLifecycleEffectLog :: LogRef -> Hook Aff LogHook { tick :: HookM Aff Unit }
 useLifecycleEffectLog log = Hooks.wrap Hooks.do
   -- used to force re-evaluation of the hook; this should not re-run the effect
   -- because lifecycle effects run only once.
-  count /\ countState <- Hooks.useState 0
+  state /\ modifyState <- Hooks.useState 0
 
   Hooks.useLifecycleEffect do
     writeLog (RunEffect (EffectBody 0)) log
     pure $ Just do
       writeLog (RunEffect (EffectCleanup 0)) log
 
-  Hooks.pure { tick: Hooks.modify_ countState (_ + 1) }
+  Hooks.pure { tick: modifyState (_ + 1) }
 
 lifecycleEffectHook :: Spec Unit
 lifecycleEffectHook = before initDriver $ describe "useLifecycleEffect" do

--- a/test/Test/Hooks/UseEffect/UseTickEffect.purs
+++ b/test/Test/Hooks/UseEffect/UseTickEffect.purs
@@ -24,13 +24,13 @@ derive instance newtypeLogHook :: Newtype (LogHook h) _
 
 useTickEffectLog :: LogRef -> Hook Aff LogHook { increment :: HookM Aff Unit, toggle :: HookM Aff Unit, count :: Int }
 useTickEffectLog log = Hooks.wrap Hooks.do
-  count /\ countState <- Hooks.useState 0
-  toggle /\ toggleState <- Hooks.useState false
+  count /\ modifyCount <- Hooks.useState 0
+  toggle /\ modifyToggle <- Hooks.useState false
   useLogger { count, id: 0 }
   Hooks.pure
     { count
-    , increment: Hooks.modify_ countState (_ + 1)
-    , toggle: Hooks.modify_ toggleState not
+    , increment: modifyCount (_ + 1)
+    , toggle: modifyToggle not
     }
   where
   useLogger deps@{ count, id } = Hooks.captures deps Hooks.useTickEffect do

--- a/test/Test/Hooks/UseMemo.purs
+++ b/test/Test/Hooks/UseMemo.purs
@@ -32,34 +32,34 @@ type MemoCount =
 
 useMemoCount :: LogRef -> Hook Aff MemoHook MemoCount
 useMemoCount log = Hooks.wrap Hooks.do
-  s1 /\ ts1 <- Hooks.useState 0
-  s2 /\ ts2 <- Hooks.useState 0
-  s3 /\ ts3 <- Hooks.useState 0
+  state1 /\ modifyState1 <- Hooks.useState 0
+  state2 /\ modifyState2 <- Hooks.useState 0
+  state3 /\ modifyState3 <- Hooks.useState 0
 
-  expensive1 <- memoize1 { s1 }
-  expensive2 <- memoize2 { s2 }
-  expensive3 <- memoize3 { s1, s2 }
+  expensive1 <- memoize1 { state1 }
+  expensive2 <- memoize2 { state2 }
+  expensive3 <- memoize3 { state1, state2 }
 
   Hooks.pure
-    { incrementA: Hooks.modify_ ts1 (_ + 1) -- recomputes 1 and 3
-    , incrementB: Hooks.modify_ ts2 (_ + 1) -- recomputes 2 and 3
-    , incrementC: Hooks.modify_ ts3 (_ + 1) -- recomputes nothing
+    { incrementA: modifyState1 (_ + 1) -- recomputes 1 and 3
+    , incrementB: modifyState2 (_ + 1) -- recomputes 2 and 3
+    , incrementC: modifyState3 (_ + 1) -- recomputes nothing
     , expensive1
     , expensive2
     , expensive3
     }
   where
-  memoize1 deps@{ s1 } = Hooks.captures deps $ flip Hooks.useMemo \_ -> do
+  memoize1 deps@{ state1 } = Hooks.captures deps $ flip Hooks.useMemo \_ -> do
     let _ = unsafeWriteLog (RunMemo (CalculateMemo 1)) log
-    s1 + 5
+    state1 + 5
 
-  memoize2 deps@{ s2 } = Hooks.captures deps $ flip Hooks.useMemo \_ -> do
+  memoize2 deps@{ state2 } = Hooks.captures deps $ flip Hooks.useMemo \_ -> do
     let _ = unsafeWriteLog (RunMemo (CalculateMemo 2)) log
-    s2 + 5
+    state2 + 5
 
-  memoize3 deps@{ s1, s2 } = Hooks.captures deps $ flip Hooks.useMemo \_ -> do
+  memoize3 deps@{ state1, state2 } = Hooks.captures deps $ flip Hooks.useMemo \_ -> do
     let _ = unsafeWriteLog (RunMemo (CalculateMemo 3)) log
-    s1 + s2 + 5
+    state1 + state2 + 5
 
 memoHook :: Spec Unit
 memoHook = before initDriver $ describe "useMemo" do

--- a/test/Test/Setup/Eval.purs
+++ b/test/Test/Setup/Eval.purs
@@ -18,9 +18,10 @@ import Halogen as H
 import Halogen.Aff.Driver.Eval as Aff.Driver.Eval
 import Halogen.Aff.Driver.State (DriverState(..), DriverStateX, initDriverState)
 import Halogen.HTML as HH
-import Halogen.Hooks (HookF(..), HookM(..), Hooked(..), StateToken(..))
+import Halogen.Hooks (HookF(..), HookM(..), Hooked(..))
 import Halogen.Hooks.Internal.Eval as Hooks.Eval
 import Halogen.Hooks.Internal.Eval.Types (HookState(..), InterpretHookReason, HalogenM')
+import Halogen.Hooks.Internal.Types (StateToken(..))
 import Halogen.Hooks.Internal.UseHookF (UseHookF)
 import Test.Setup.Log (writeLog)
 import Test.Setup.Types (DriverResultState, LogRef, TestEvent(..), HalogenF')


### PR DESCRIPTION
This PR removes state tokens from public use in the Hooks library in favor of an explicit modify function returned by the `useState` hook.

Before:

```purs
state /\ stateToken <- Hooks.useState 0
let handleClick = Hooks.modify_ stateToken (_ + 1)
Hooks.pure ...
```

After:

```purs
state /\ modifyState <- Hooks.useState 0
let handleClick = modifyState (_ + 1)
Hooks.pure ...
```

I wanted to introduce this change for several reasons.

1. A `modifyState` function is familiar to anyone used to using Halogen's `modify_` function, or to folks who have used React Hooks before.
2. This change makes tokens purely a way to opt-in to component features like queries and messages, which keeps the concept about using a token to get an outside-of-hooks feature
3. The state token has caused confusion several times (what is it? if I pass it to a function will my code break? if I pass it to a nested hook?), but a modify function is normal.
4. Naming is a little bit weird with the tokens -- everyone started using different conventions right away (`count /\ countState`? `count /\ countToken`? `count /\ tCount`?). A modify function cleans up this rough edge (`count /\ modifyCount`).

However, the downside is that we depart even further from ordinary `HalogenM` code by removing the usual `put`, `get`, `modify`, and `modify_` functions.

I was on the fence about this for a while, especially because I wanted it to be easy to `get` the current state in an effect cleanup to avoid using stale state. But then I was asked about a situation in which the Hook _input_ could get stale in an effect cleanup, and I realized that avoiding stale input and avoiding stale state come down to the same thing: you have to store the value in a mutable reference if you want to read the up-to-date value later on.

If you already have to do that for component input then it may as well be the same way to approach getting the current state or any other value in an effect cleanup, too.

To make that clearer I've added new documentation on avoiding stale state / input and I've added an example `useGet` Hook inspired by a similar Hook we use in our React codebase at work.