### PR TITLE
Use mutable state internally with STRecord & STArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If Halogen Hooks is not available in your package set, add it to your project's 
 ```dhall
 let additions =
   { halogen-hooks =
-      { dependencies = [ "halogen", "indexed-monad" ]
+      { dependencies = [ "halogen", "indexed-monad", "record" ]
       , repo = "https://github.com/thomashoneyman/purescript-halogen-hooks.git"
       , version = "master"
       }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,20 +1,14 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.5-20200103/packages.dhall sha256:0a6051982fb4eedb72fbe5ca4282259719b7b9b525a4dda60367f98079132f30
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200507/packages.dhall sha256:9c1e8951e721b79de1de551f31ecb5a339e82bbd43300eb5ccfb1bf8cf7bbd62
 
 let overrides = {=}
 
 let additions =
-  { halogen-storybook =
-      { dependencies =
-          [ "halogen"
-          , "routing"
-          , "foreign-object"
-          ]
-      , repo =
-          "https://github.com/rnons/purescript-halogen-storybook.git"
-      , version =
-          "v1.0.0-rc.1"
+      { halogen-storybook =
+          { dependencies = [ "halogen", "routing", "foreign-object" ]
+          , repo = "https://github.com/rnons/purescript-halogen-storybook.git"
+          , version = "v1.0.0-rc.1"
+          }
       }
-  }
 
 in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,7 +1,7 @@
 { name = "halogen-hooks"
 , license = "MIT"
 , repository = "https://github.com/thomashoneyman/purescript-halogen-hooks"
-, dependencies = [ "halogen", "indexed-monad" ]
+, dependencies = [ "halogen", "indexed-monad", "record" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]
 }

--- a/src/Halogen/Hooks/Internal/Eval/Types.purs
+++ b/src/Halogen/Hooks/Internal/Eval/Types.purs
@@ -2,24 +2,35 @@ module Halogen.Hooks.Internal.Eval.Types where
 
 import Prelude
 
+import Control.Monad.ST.Class (liftST)
+import Control.Monad.ST.Global (Global)
+import Data.Array.ST (STArray)
+import Data.Array.ST as Array.ST
+import Data.Array.ST.Partial as Array.ST.Partial
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
+import Data.Symbol (class IsSymbol, SProxy(..))
 import Data.Tuple.Nested (type (/\))
 import Effect.Ref (Ref)
+import Effect.Unsafe (unsafePerformEffect)
 import Halogen as H
 import Halogen.Hooks.HookM (HookM)
 import Halogen.Hooks.Internal.Types (MemoValue, OutputValue, RefValue, SlotType, StateValue)
 import Halogen.Hooks.Types (MemoValues, OutputToken, SlotToken)
+import Partial.Unsafe (unsafePartial)
+import Record.ST (STRecord)
+import Record.ST as Record.ST
+import Type.Row (class Cons) as Row
 import Unsafe.Coerce (unsafeCoerce)
 
-type HalogenM' q i m b a = H.HalogenM (HookState q i m b) (HookM m Unit) SlotType OutputValue m a
+type HalogenM' q i m b a = H.HalogenM (State q i m b) (HookM m Unit) SlotType OutputValue m a
 
 toHalogenM
   :: forall q i ps o m b a
    . SlotToken ps
   -> OutputToken o
   -> HalogenM' q i m b a
-  -> H.HalogenM (HookState q i m b) (HookM m Unit) ps o m a
+  -> H.HalogenM (State q i m b) (HookM m Unit) ps o m a
 toHalogenM slotToken outputToken hm = unsafeCoerce hm
 
 data InterpretHookReason
@@ -45,25 +56,96 @@ toQueryFn = unsafeCoerce
 fromQueryFn :: forall q m. QueryFn q m -> (forall a. q a -> HookM m (Maybe a))
 fromQueryFn = unsafeCoerce
 
-newtype HookState q i m a = HookState
+-- STRecord
+newtype State q i m a = State
   { result :: a
-  , stateRef :: Ref (InternalHookState q i m a)
+  , internal :: STRecord Global (InternalState q i m a)
   }
 
-derive instance newtypeHookState :: Newtype (HookState q i m a) _
+derive instance newtypeState :: Newtype (State q i m a) _
 
-type InternalHookState q i m a =
-  { input :: i
+type InternalState q i m a =
+  ( input :: i
   , queryFn :: Maybe (QueryFn q m)
-  , evalQueue :: Array (H.HalogenM (HookState q i m a) (HookM m Unit) SlotType OutputValue m Unit)
-  , stateCells :: QueueState StateValue
-  , effectCells :: QueueState ((Maybe MemoValues) /\ HookM m Unit)
-  , memoCells :: QueueState (MemoValues /\ MemoValue)
-  , refCells :: QueueState (Ref RefValue)
+  , evalQueue :: STArray Global (HalogenM' q i m a Unit)
   , stateDirty :: Boolean
-  }
 
-type QueueState a =
-  { queue :: Array a
-  , index :: Int
-  }
+  , stateCells :: STArray Global StateValue
+  , stateIndex :: Int
+
+  , effectCells :: STArray Global ((Maybe MemoValues) /\ HookM m Unit)
+  , effectIndex :: Int
+
+  , memoCells :: STArray Global (MemoValues /\ MemoValue)
+  , memoIndex :: Int
+
+  , refCells :: STArray Global (Ref RefValue)
+  , refIndex :: Int
+  )
+
+_input = SProxy :: SProxy "input"
+_queryFn = SProxy :: SProxy "queryFn"
+_evalQueue = SProxy :: SProxy "evalQueue"
+_stateDirty = SProxy :: SProxy "stateDirty"
+_stateCells = SProxy :: SProxy "stateCells"
+_stateIndex = SProxy :: SProxy "stateIndex"
+_effectCells = SProxy :: SProxy "effectCells"
+_effectIndex = SProxy :: SProxy "effectIndex"
+_memoCells = SProxy :: SProxy "memoCells"
+_memoIndex = SProxy :: SProxy "memoIndex"
+_refCells = SProxy :: SProxy "refCells"
+_refIndex = SProxy :: SProxy "refIndex"
+
+-- | Read a field from the internal state, without creating an immutable copy
+getInternalField
+  :: forall q i m b l a r
+   . Row.Cons l a r (InternalState q i m b)
+  => IsSymbol l
+  => SProxy l
+  -> HalogenM' q i m b a
+getInternalField field = do
+  State { internal } <- H.get
+  pure $ unsafePerformEffect $ liftST $ Record.ST.peek field internal
+
+-- | Modify a field in the internal state, without creating an immutable copy
+modifyInternalField
+  :: forall q i m b l a r
+   . Row.Cons l a r (InternalState q i m b)
+  => IsSymbol l
+  => SProxy l
+  -> (a -> a)
+  -> HalogenM' q i m b Unit
+modifyInternalField field fn = do
+  State { internal } <- H.get
+  pure $ unsafePerformEffect $ liftST $ Record.ST.modify field fn internal
+
+pushField
+  :: forall q i m b l a r
+   . Row.Cons l (STArray Global a) r (InternalState q i m b)
+  => IsSymbol l
+  => SProxy l
+  -> a
+  -> HalogenM' q i m b Unit
+pushField l a = do
+  array <- getInternalField l
+  let _ = unsafePerformEffect $ liftST $ Array.ST.push a array
+  pure unit
+
+unwrapSTArray :: forall a. STArray Global a -> Array a
+unwrapSTArray = unsafePerformEffect <<< liftST <<< Array.ST.freeze
+
+unsafeGetCell :: forall q i m b a. Int -> STArray Global a -> HalogenM' q i m b a
+unsafeGetCell ix arr =
+  pure
+    $ unsafePerformEffect
+    $ liftST
+    $ unsafePartial
+    $ Array.ST.Partial.peek ix arr
+
+unsafeSetCell :: forall q i m b a. Int -> a -> STArray Global a -> HalogenM' q i m b Unit
+unsafeSetCell ix a arr =
+  pure
+    $ unsafePerformEffect
+    $ liftST
+    $ unsafePartial
+    $ Array.ST.Partial.poke ix a arr

--- a/test/Test/Setup/Types.purs
+++ b/test/Test/Setup/Types.purs
@@ -10,12 +10,12 @@ import Halogen as H
 import Halogen.Aff.Driver.State (DriverState)
 import Halogen.HTML as HH
 import Halogen.Hooks (HookM)
-import Halogen.Hooks.Internal.Eval.Types (HookState, InterpretHookReason)
+import Halogen.Hooks.Internal.Eval.Types (State, InterpretHookReason)
 import Halogen.Hooks.Internal.Types (OutputValue, SlotType)
 
-type HalogenF' q i m b a = H.HalogenF (HookState q i m b) (HookM m Unit) SlotType OutputValue m a
+type HalogenF' q i m b a = H.HalogenF (State q i m b) (HookM m Unit) SlotType OutputValue m a
 
-type DriverResultState r q a = DriverState HH.HTML r (HookState q LogRef Aff a) q (HookM Aff Unit) SlotType LogRef OutputValue
+type DriverResultState r q a = DriverState HH.HTML r (State q LogRef Aff a) q (HookM Aff Unit) SlotType LogRef OutputValue
 
 type LogRef = Ref Log
 


### PR DESCRIPTION
Hooks has always shipped with mutable internal state -- all internal state was always behind a `Ref` so that updating it would not trigger renders.

However, we were storing immutable data in a mutable reference. Each operation on that data still creates a new data structure. This commit changes the internals to be fully mutable, which means that Hook evaluations occur on the same mutable object internally.

Consumers of the library should see no change -- this is purely an internal optimization.