### PR TITLE
Throw exception if state-modifying HookM code passed between components

### DIFF
--- a/src/Halogen/Hooks/Component.purs
+++ b/src/Halogen/Hooks/Component.purs
@@ -14,7 +14,7 @@ import Halogen.Hooks.Hook (Hooked(..))
 import Halogen.Hooks.HookM (HookM)
 import Halogen.Hooks.Internal.Eval (evalHookM, interpretHook, mkEval, getState)
 import Halogen.Hooks.Internal.Eval.Types (HookState(..), toHalogenM)
-import Halogen.Hooks.Types (ComponentRef, ComponentTokens, OutputToken(..), QueryToken(..), SlotToken(..))
+import Halogen.Hooks.Types (ComponentRef, ComponentTokens, OutputToken, QueryToken, SlotToken)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Produces a Halogen component from a `Hook` which returns `ComponentHTML`.
@@ -90,9 +90,9 @@ memoComponent
   -> H.Component HH.HTML q i o m
 memoComponent eqInput inputHookFn = do
   let
-    queryToken = UnsafeQueryToken :: QueryToken q
-    slotToken = UnsafeSlotToken :: SlotToken s
-    outputToken = UnsafeOutputToken :: OutputToken o
+    queryToken = unsafeCoerce {} :: QueryToken q
+    slotToken = unsafeCoerce {} :: SlotToken s
+    outputToken = unsafeCoerce {} :: OutputToken o
     hookFn = inputHookFn { queryToken, slotToken, outputToken }
 
   H.mkComponent

--- a/src/Halogen/Hooks/Internal/Eval.purs
+++ b/src/Halogen/Hooks/Internal/Eval.purs
@@ -280,8 +280,15 @@ evalHookM (H.HalogenM runHooks) (HookM evalUseHookF) =
       --
       -- This leads either to unexpected state modifications or a crash when an
       -- index in state is accessed that doesn't exist.
-      unless (unsafeRefEq state.componentRef ref) do
-        unsafeThrow "Attempted to use state-modifying `HookM` code outside the component where it was defined."
+      let matchesRef = unsafeRefEq state.componentRef ref
+
+      -- Using `unless` here throws an exception -- strictness? Using `case`
+      -- behaves as expected
+      case matchesRef of
+        true ->
+          pure unit
+        _ ->
+          unsafeThrow "Attempted to use state-modifying `HookM` code outside the component where it was defined."
 
       let
         current = unsafeGetCell id state.stateCells.queue

--- a/src/Halogen/Hooks/Internal/Eval/Types.purs
+++ b/src/Halogen/Hooks/Internal/Eval/Types.purs
@@ -9,7 +9,7 @@ import Effect.Ref (Ref)
 import Halogen as H
 import Halogen.Hooks.HookM (HookM)
 import Halogen.Hooks.Internal.Types (MemoValue, OutputValue, RefValue, SlotType, StateValue)
-import Halogen.Hooks.Types (MemoValues, OutputToken, SlotToken)
+import Halogen.Hooks.Types (ComponentRef, MemoValues, OutputToken, SlotToken)
 import Unsafe.Coerce (unsafeCoerce)
 
 type HalogenM' q i m b a = H.HalogenM (HookState q i m b) (HookM m Unit) SlotType OutputValue m a
@@ -54,6 +54,7 @@ derive instance newtypeHookState :: Newtype (HookState q i m a) _
 
 type InternalHookState q i m a =
   { input :: i
+  , componentRef :: ComponentRef
   , queryFn :: Maybe (QueryFn q m)
   , evalQueue :: Array (H.HalogenM (HookState q i m a) (HookM m Unit) SlotType OutputValue m Unit)
   , stateCells :: QueueState StateValue

--- a/src/Halogen/Hooks/Types.purs
+++ b/src/Halogen/Hooks/Types.purs
@@ -1,5 +1,7 @@
 module Halogen.Hooks.Types where
 
+import Data.Tuple (Tuple)
+
 -- | A unique identifier for a state produced by `useState`, which can be passed
 -- | to the state functions `get`, `put`, `modify`, and `modify_` to get or
 -- | modify the state.
@@ -12,7 +14,9 @@ module Halogen.Hooks.Types where
 -- | let
 -- |   handler = Hooks.modify_ stateId (_ + 10)
 -- | ```
-newtype StateId state = StateId Int
+newtype StateId state = StateId (Tuple ComponentRef Int)
+
+data ComponentRef
 
 -- | The set of tokens enabling queries, child slots, and output messages when
 -- | running a Hook as a component. This set of tokens is provided by the
@@ -34,14 +38,14 @@ type ComponentTokens q ps o =
 -- | relationship, and so they are not tracked in Hook types.
 -- |
 -- | This token is provided by the `component` function.
-foreign import data QueryToken :: (Type -> Type) -> Type
+data QueryToken (a :: Type -> Type) = UnsafeQueryToken
 
 -- | A token which carries the type of child slots supported by the component
 -- | which is executing a Hook. Child slots are specific to the parent-child
 -- | component relationship, and so they are not tracked in Hook types.
 -- |
 -- | This token is provided by the `component` function.
-foreign import data SlotToken :: # Type -> Type
+data SlotToken (slots :: # Type) = UnsafeSlotToken
 
 -- | A token which carries the type of outputs supported by the component
 -- | which is executing a Hook. Output messages slots are specific to the
@@ -49,10 +53,10 @@ foreign import data SlotToken :: # Type -> Type
 -- | Hook types.
 -- |
 -- | This token is provided by the `component` function.
-foreign import data OutputToken :: Type -> Type
+data OutputToken output = UnsafeOutputToken
 
 -- | An opaque type which signifies that a set of dependencies have been captured
 -- | and can be used by Hooks like `UseMemo` and `UseEffect`.
 -- |
 -- | This type is provided by the `captures` and `capturesWith` functions.
-foreign import data MemoValues :: Type
+data MemoValues

--- a/src/Halogen/Hooks/Types.purs
+++ b/src/Halogen/Hooks/Types.purs
@@ -16,6 +16,9 @@ import Data.Tuple (Tuple)
 -- | ```
 newtype StateId state = StateId (Tuple ComponentRef Int)
 
+-- | A unique reference for a component, which is used to track which component
+-- | Hooks code is defined in to ensure that it isn't run in another component
+-- | (this is unsafe, and doing so will throw an exception).
 data ComponentRef
 
 -- | The set of tokens enabling queries, child slots, and output messages when
@@ -38,14 +41,14 @@ type ComponentTokens q ps o =
 -- | relationship, and so they are not tracked in Hook types.
 -- |
 -- | This token is provided by the `component` function.
-data QueryToken (a :: Type -> Type) = UnsafeQueryToken
+data QueryToken (a :: Type -> Type)
 
 -- | A token which carries the type of child slots supported by the component
 -- | which is executing a Hook. Child slots are specific to the parent-child
 -- | component relationship, and so they are not tracked in Hook types.
 -- |
 -- | This token is provided by the `component` function.
-data SlotToken (slots :: # Type) = UnsafeSlotToken
+data SlotToken (slots :: # Type)
 
 -- | A token which carries the type of outputs supported by the component
 -- | which is executing a Hook. Output messages slots are specific to the
@@ -53,7 +56,7 @@ data SlotToken (slots :: # Type) = UnsafeSlotToken
 -- | Hook types.
 -- |
 -- | This token is provided by the `component` function.
-data OutputToken output = UnsafeOutputToken
+data OutputToken output
 
 -- | An opaque type which signifies that a set of dependencies have been captured
 -- | and can be used by Hooks like `UseMemo` and `UseEffect`.

--- a/test/Test/Setup/Eval.purs
+++ b/test/Test/Setup/Eval.purs
@@ -11,6 +11,7 @@ import Data.Newtype (over, unwrap)
 import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff)
 import Effect.Class (class MonadEffect, liftEffect)
+import Effect.Exception.Unsafe (unsafeThrow)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen (HalogenQ)
@@ -23,7 +24,7 @@ import Halogen.Hooks.Internal.Eval as Hooks.Eval
 import Halogen.Hooks.Internal.Eval.Types (HookState(..), InterpretHookReason, HalogenM')
 import Halogen.Hooks.Internal.Types (OutputValue, SlotType)
 import Halogen.Hooks.Internal.UseHookF (UseHookF)
-import Halogen.Hooks.Types (StateId(..))
+import Halogen.Hooks.Types (ComponentRef, StateId(..))
 import Test.Setup.Log (writeLog)
 import Test.Setup.Types (DriverResultState, LogRef, TestEvent(..), HalogenF')
 import Unsafe.Coerce (unsafeCoerce)
@@ -60,9 +61,14 @@ evalHookM runHooks (HookM hm) = foldFree go hm
   where
   go :: HookF Aff ~> HalogenM' q LogRef Aff a
   go = case _ of
-    c@(Modify (StateId token) f reply) -> do
+    c@(Modify (StateId (Tuple ref id)) f reply) -> do
       state <- H.HalogenM Hooks.Eval.getState
-      let v = Hooks.Eval.unsafeGetCell token state.stateCells.queue
+
+      unless (unsafeRefEq state.componentRef ref) do
+        unsafeThrow "Attempted to use state-modifying HookM code outside the component where it was defined."
+
+      let
+        v = Hooks.Eval.unsafeGetCell id state.stateCells.queue
 
       -- Calls to `get` should not trigger evaluation. This matches with the
       -- underlying implementation of `evalHookM` and Halogen's `evalM`.
@@ -106,14 +112,15 @@ mkEval
    . (LogRef -> Hooked Aff Unit h b)
   -> (Unit -> HalogenQ q (HookM Aff Unit) LogRef Unit)
   -> HalogenM' q LogRef Aff b Unit
-mkEval h = mkEvalQuery h `compose` H.tell
+mkEval h q = mkEvalQuery h (H.tell q)
 
 mkEvalQuery
   :: forall h q b a
    . (LogRef -> Hooked Aff Unit h b)
   -> HalogenQ q (HookM Aff Unit) LogRef a
   -> HalogenM' q LogRef Aff b a
-mkEvalQuery = Hooks.Eval.mkEval (\_ _ -> false) evalHookM (interpretUseHookFn evalHookM)
+mkEvalQuery =
+  Hooks.Eval.mkEval (\_ _ -> false) evalHookM (interpretUseHookFn evalHookM)
   where
   -- WARNING: Unlike the other functions, this one needs to be manually kept in
   -- sync with the implementation in the main Hooks library. If you change this
@@ -143,6 +150,7 @@ initDriver = liftEffect do
 
   stateRef <- Ref.new
     { input: logRef
+    , componentRef: unsafeCoerce {} :: ComponentRef
     , queryFn: Nothing
     , stateCells: { queue: [], index: 0 }
     , effectCells: { queue: [], index: 0 }


### PR DESCRIPTION
In #37, @marcusbuffett noticed that weird behavior can occur if you pass `HookM` code that modifies state from a parent component to a child component which executes it. 

Short version: **you can't pass state-modifying `HookM` code between components.** It is possible to support this (as noted in #37) but the solution has its own drawbacks. This PR throws an exception if you try to do this.

Longer version: This happens because `HookM` describes what actions the Hook interpreter should take, where the interpreter is the component that runs the code. If you say that you should modify the state at a particular `StateId`, then the interpreter will do just that -- even if the component executing the Hooks code doesn't have any state at that index, or the state is the wrong type.

This situation is rare; you can freely pass `HookM` code among Hooks and you can even pass it among components, so long as it doesn't modify state. But you can't pass this code among components. The library takes care to hide state types for usability, but in this instance it can cause a problem.

As a short-term solution, state identifiers now track a reference to the component where they were originally created (their original interpreter). If they are used outside that component then the Halogen app will throw an exception stating:

```
Uncaught Error: Attempted to use state-modifying `HookM` code outside the component where it was defined.
```

This at least provides a better error message than what you see if the state index doesn't exist:

```
Error: Failed pattern match at Data.Maybe (line 268, column 1 - line 268, column 46): Nothing
```

Not to mention how hard it might be to track down a subtle bug where the state being modified is not what you expect, but which exists and has the right type.