### PR TITLE
Add tip for dealing with unused token types

### DIFF
--- a/src/Halogen/Hooks/Component.purs
+++ b/src/Halogen/Hooks/Component.purs
@@ -44,7 +44,7 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | better type inference if you annotate the token type:
 -- |
 -- | ```purs
--- | type Tokens = ComponentTokens MyQuery MySlots MyOutput
+-- | type Tokens = Hooks.ComponentTokens MyQuery MySlots MyOutput
 -- |
 -- | myComponent :: forall i m. H.Component MyQuery i MyOutput m
 -- | myComponent = Hooks.component \(tokens :: Tokens) _ -> Hooks.do
@@ -53,7 +53,7 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | Use type variables to substitue unused token types:
 -- |
 -- | ```purs
--- | type Tokens s o = ComponentTokens MyQuery s o
+-- | type Tokens s o = Hooks.ComponentTokens MyQuery s o
 -- |
 -- | myComponent :: forall i o m. H.Component MyQuery i o m
 -- | myComponent = Hooks.component \(tokens :: Tokens _ o) _ -> Hooks.do

--- a/src/Halogen/Hooks/Component.purs
+++ b/src/Halogen/Hooks/Component.purs
@@ -49,6 +49,15 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | myComponent :: forall i m. H.Component MyQuery i MyOutput m
 -- | myComponent = Hooks.component \(tokens :: Tokens) _ -> Hooks.do
 -- |   ... hook implementation
+-- |
+-- | Use type variables to substitue unused token types:
+-- |
+-- | ```purs
+-- | type Tokens s o = ComponentTokens MyQuery s o
+-- |
+-- | myComponent :: forall i o m. H.Component MyQuery i o m
+-- | myComponent = Hooks.component \(tokens :: Tokens _ o) _ -> Hooks.do
+-- |   ... hook implementation
 -- | ```
 component
   :: forall hooks q i ps o m


### PR DESCRIPTION
This may be more of a remedial lesson on PureScript, but I'm not sure how obvious this is to beginners.
I think it's better to include this note, than have users try to figure out what concrete types are necessary to represent an unused Query, Slot, or Output.