### PR TITLE
Add references to the PureScript cookbook and hooks-extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Learn more about Hooks:
 1. [Read the blog post introducing Halogen Hooks](https://thomashoneyman.com/articles/introducing-halogen-hooks)
 2. [Read the Halogen Hooks documentation](./docs)
 3. [View the component and custom hook examples](./examples)
+4. [View the Hooks recipes in the PureScript Cookbook](https://github.com/JordanMartinez/purescript-cookbook)
 
 ## Installation
 

--- a/docs/01-Hooks-At-A-Glance.md
+++ b/docs/01-Hooks-At-A-Glance.md
@@ -1,6 +1,6 @@
 # Hooks at a Glance
 
-Hooks are a new library for Halogen. This page provides an overview of using Hooks for experienced Halogen users. If you haven't read it yet, you should [read Introducing Halogen Hooks](https://thomashoneyman.com/articles/introducing-halogen-hooks) to understand the motivation for Hooks.
+Hooks are a new library for Halogen. This page provides an overview of using Hooks for experienced Halogen users. If you haven't read it yet, you should [read Introducing Halogen Hooks](https://thomashoneyman.com/articles/introducing-halogen-hooks) to understand the motivation for Hooks. You may also be interested in the Hooks recipes in the [PureScript Cookbook](https://github.com/JordanMartinez/purescript-cookbook) to see some common tasks implemented with Hooks.
 
 This is a fast-paced overview. If you're new to Halogen you should take time to get familiar with essential Halogen concepts like input, state, and `HalogenM` before you read this.
 
@@ -60,7 +60,7 @@ We're destructuring the tuple that `useState` returns using the tuple operator `
 
 ### Using a modify function instead of an identifier
 
-If you prefer your `useState` Hook to return a modify function directly, instead of an identifier, you can use the `Functor` instance for Hooks to apply a state function to the identifier returned by the hook.
+If you prefer your `useState` Hook to return a modify function directly, instead of an identifier, you can use the `Functor` instance for Hooks to apply a state function to the identifier returned by the hook as seen in the example below (`useStateFn`, as well as variants like `useModifyState`, are available in the [halogen-hooks-extra](https://github.com/JordanMartinez/purescript-halogen-hooks-extra) package).
 
 ```purs
 -- You can provide any of the Hooks state functions to this function.

--- a/docs/07-Hooks-API.md
+++ b/docs/07-Hooks-API.md
@@ -45,7 +45,7 @@ Hooks.do
 
 In a regular Halogen component, any time your state updates your component will re-render. Hooks operate in a similar fashion: any time one of your state cells updates, your Hooks will re-run.
 
-Most of the time you only need the `modify_` function for your state. If you prefer the `useState` hook to just return the modify function directly, you can do so like this:
+Most of the time you only need the `modify_` function for your state. It can be convenient to have the `useState` hook just return a function to modify the state instead of returning a `StateId`; if you prefer that, you can implement a helper function like `useStateFn` in the example below (`useStateFn` and other helpers are available in the [halogen-hooks-extra](https://github.com/JordanMartinez/purescript-halogen-hooks-extra) package):
 
 ```purs
 -- To allow using any state function

--- a/docs/08-Hooks-FAQ.md
+++ b/docs/08-Hooks-FAQ.md
@@ -104,6 +104,8 @@ state /\ (setState :: Int -> HookM m Unit) <- useStateFn Hooks.put 0
 state /\ (modifyState :: ((Int -> Int) -> HookM m Unit) <- useStateFn Hooks.modify_ 0
 ```
 
+`useStateFn` and many other helper functions are available in the [halogen-hooks-extra](https://github.com/JordanMartinez/purescript-halogen-hooks-extra) package.
+
 ### Why am I seeing stale input or state?
 
 If you define a function in one Hooks evaluation which is going to be run during or after another Hooks evaluation, and this function refers to an `input` value or a value returned by `useState`, then the function will probably see a stale value when it runs. That's because `input` and values returned by `useState` are not mutable references; when your function runs, it will still be pointing at the value that existed when it was defined.


### PR DESCRIPTION
Closes #50 and closes #51 by linking to the hooks-extra package and the PureScript Cookbook in the project documentation.