### PR TITLE
Switch to use setup-purescript in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Use Node.js
-        uses: actions/setup-node@v1
+      - uses: thomashoneyman/setup-purescript@master
+      - uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-
-      - name: Install PureScript
-        run: npm install -g purescript
-
-      - name: Install Spago
-        run: npm install -g spago
 
       - name: Install test dependencies
         run: npm install

--- a/shell.nix
+++ b/shell.nix
@@ -1,20 +1,21 @@
 let
   pkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/19.09.tar.gz";
+    url = "https://github.com/NixOS/nixpkgs/archive/20.03.tar.gz";
   }) {};
 
-  # 2020-03-16 nix-prefetch-git https://github.com/justinwoo/easy-purescript-nix
+  # 2020-08-01 nix-prefetch-git https://github.com/justinwoo/easy-purescript-nix
   pursPkgs = import (pkgs.fetchFromGitHub {
     owner = "justinwoo";
     repo = "easy-purescript-nix";
-    rev = "aa3e608608232f4a009b5c132ae763fdabfb4aba";
-    sha256 = "0y6jikncxs9l2zgngbd1775f1zy5s1hdc5rhkyzsyaalcl5cajk8";
+    rev = "7ff5a12af5750f94d0480059dba0ba6b82c6c452";
+    sha256 = "0af25dqhs13ii4mx9jjkx2pww4ddbs741vb5gfc5ckxb084d69fq";
   }) {};
 
 in pkgs.stdenv.mkDerivation {
-  name = "halogen-hooks";
+  name = "setup-purescript";
   buildInputs = with pursPkgs; [
-    purs spago purty pscid
-    pkgs.yarn pkgs.nodejs-12_x
+    pursPkgs.purs
+    pursPkgs.spago
+    pkgs.nodejs-12_x
   ];
 }


### PR DESCRIPTION
The [setup-purescript](https://github.com/thomashoneyman/setup-purescript) GitHub Action automatically includes a PureScript toolchain, which means we can skip the NPM install in CI.