### PR TITLE
Tweak comment about debugging visually

### DIFF
--- a/test/Test/Setup/Performance/Measure.purs
+++ b/test/Test/Setup/Performance/Measure.purs
@@ -36,7 +36,7 @@ type ComparisonSummary =
 
 -- | Bracket test runs by supplying a new browser to each one
 withBrowser :: (Browser -> Aff Unit) -> Aff Unit
-withBrowser = bracket Puppeteer.launch Puppeteer.closeBrowser
+withBrowser = bracket (Puppeteer.launch { headless: true }) Puppeteer.closeBrowser
 
 data TestType = StateTest | TodoTest
 

--- a/test/Test/Setup/Performance/Puppeteer.js
+++ b/test/Test/Setup/Performance/Puppeteer.js
@@ -7,8 +7,10 @@ exports.filterConsole = function () {
   filterConsole(["Failed to parse CPU profile."]);
 };
 
-exports.launchImpl = function () {
-  return puppeteer.launch(); // to debug visually, set { headless: false }
+exports.launchImpl = function (args) {
+  return function() {
+    return puppeteer.launch(args);
+  }
 };
 
 exports.newPageImpl = function (browser) {

--- a/test/Test/Setup/Performance/Puppeteer.js
+++ b/test/Test/Setup/Performance/Puppeteer.js
@@ -8,7 +8,7 @@ exports.filterConsole = function () {
 };
 
 exports.launchImpl = function () {
-  return puppeteer.launch(); // to debug visually, set { headless: true }
+  return puppeteer.launch(); // to debug visually, set { headless: false }
 };
 
 exports.newPageImpl = function (browser) {

--- a/test/Test/Setup/Performance/Puppeteer.purs
+++ b/test/Test/Setup/Performance/Puppeteer.purs
@@ -54,10 +54,16 @@ foreign import filterConsole :: Effect Unit
 -- | the start of any Puppeteer session and closed at the end.
 foreign import data Browser :: Type
 
-foreign import launchImpl :: Effect (Promise Browser)
+-- | The headless :: Boolean argument specifies whether or not to run the browser in headless mode.
+-- | To debug/test visually, set headless to false
+type LaunchArgs =
+  { headless :: Boolean
+  }
 
-launch :: Aff Browser
-launch = toAffE launchImpl
+foreign import launchImpl :: LaunchArgs -> Effect (Promise Browser)
+
+launch :: LaunchArgs -> Aff Browser
+launch config = toAffE (launchImpl config)
 
 -- | An instance of a Puppeteer page, which is necessary to run page-level
 -- | functions like collecting metrics and starting and stopping traces.


### PR DESCRIPTION
There is a comment telling the user how to enable testing visually, but the setting in the comment actually makes the browser run in headless mode (which is the default) where there is no visual indication.