### PR TITLE
Remove HookEquals newtype and prevent Hooks coercions in 0.14

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,9 @@ Notable changes to Hooks are documented in this file. The format is based on [Ke
 
 Breaking changes (😱!!!):
 
-- **Move to a single index for hook types ([#32](https://github.com/thomashoneyman/purescript-halogen-hooks/pull/32)).**
+- **Add support for PureScript 0.14 and Halogen 6, dropping support for previous versions of the compiler and Halogen.** (#71 by @CarstenKoenig, #72 by @thomashoneyman)
+
+- **Move to a single index for hook types.** (#32 by @thomashoneyman)
 
   Using a single index for Hook types simplifies the Hooks implementation and makes defining your own Hooks easier and less confusing. It also allows the library to drop its dependency on `indexed-monad`.
 
@@ -40,7 +42,7 @@ Breaking changes (😱!!!):
 
   bind
     :: forall h h' m a b
-    . Hook m h a
+     . Hook m h a
     -> (a -> Hook m h' b)
     -> Hook m (h <> h') b
   ```
@@ -79,7 +81,7 @@ Breaking changes (😱!!!):
 
   foreign import data UseX :: Hooks.HookType
 
-  instance newtypeUseX :: HookEquals UseX' h => HookNewtype UseX h
+  instance newtypeUseX :: HookNewtype UseX UseX'
   ```
 
 New features:
@@ -88,9 +90,9 @@ Bugfixes:
 
 Other improvements:
 
-- Docs: Added technical documentation that covers the main concepts used in the internal implementation ([#59](https://github.com/thomashoneyman/purescript-halogen-hooks/pull/59)).
-- Docs: Added a changelog to record changes to the library over time ([#62](https://github.com/thomashoneyman/purescript-halogen-hooks/pull/62)).
-- Tests: Added performance tests to measure the performance impact of changes ([#53](https://github.com/thomashoneyman/purescript-halogen-hooks/pull/53), [#56](https://github.com/thomashoneyman/purescript-halogen-hooks/pull/56)).
+- Docs: Added technical documentation that covers the main concepts used in the internal implementation (#59 by @thomashoneyman).
+- Docs: Added a changelog to record changes to the library over time (#62 by @thomashoneyman).
+- Tests: Added performance tests to measure the performance impact of changes (#53 by @thomashoneyman, #56 by @thomashoneyman).
 
 ## [0.4.3] - 2020-06-17
 
@@ -118,7 +120,7 @@ This release includes small internal performance improvements.
 
 Improvements:
 
-- **Use `substFree` instead of `foldFree` internally ([#33](https://github.com/thomashoneyman/purescript-halogen-hooks/pull/33)).**
+- Use `substFree` instead of `foldFree` internally ([#33](https://github.com/thomashoneyman/purescript-halogen-hooks/pull/33)).
   Using `foldFree` is convenient, but it incurs some overhead due to a `MonadRec` constraint on the monad you interpret into. Switching to `substFree` eliminates this overhead, giving the library a modest performance improvement.
 
 ## [0.4.0] - 2020-05-14

--- a/examples/Example/Hooks/UseDebouncer.purs
+++ b/examples/Example/Hooks/UseDebouncer.purs
@@ -15,14 +15,14 @@ import Effect.Aff.AVar as AVar
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (liftEffect)
 import Effect.Ref as Ref
-import Halogen.Hooks (class HookEquals, class HookNewtype, type (<>), Hook, HookM, UseRef)
+import Halogen.Hooks (class HookNewtype, type (<>), Hook, HookM, UseRef)
 import Halogen.Hooks as Hooks
 
 foreign import data UseDebouncer :: Type -> Hooks.HookType
 
 type UseDebouncer' a = UseRef (Maybe Debouncer) <> UseRef (Maybe a) <> Hooks.Pure
 
-instance newtypeUseDebouncer :: HookEquals (UseDebouncer' a) h => HookNewtype (UseDebouncer a) h
+instance newtypeUseDebouncer :: HookNewtype (UseDebouncer a) (UseDebouncer' a)
 
 type Debouncer = { var :: AVar Unit, fiber :: Fiber Unit }
 

--- a/examples/Example/Hooks/UseLocalStorage.purs
+++ b/examples/Example/Hooks/UseLocalStorage.purs
@@ -16,7 +16,7 @@ import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\), type (/\))
 import Effect.Class (class MonadEffect, liftEffect)
 import Example.Hooks.UseInitializer (UseInitializer, useInitializer)
-import Halogen.Hooks (class HookEquals, class HookNewtype, type (<>), Hook, HookM, UseEffect, UseState)
+import Halogen.Hooks (class HookNewtype, type (<>), Hook, HookM, UseEffect, UseState)
 import Halogen.Hooks as Hooks
 import Web.HTML (window)
 import Web.HTML.Window (localStorage)
@@ -30,9 +30,7 @@ type UseLocalStorage' a =
     <> UseEffect
     <> Hooks.Pure
 
-instance newtypeUseLocalStorage
-  :: HookEquals (UseLocalStorage' a) h
-  => HookNewtype (UseLocalStorage a) h
+instance newtypeUseLocalStorage :: HookNewtype (UseLocalStorage a) h
 
 type StorageInterface a =
   { key :: Key

--- a/examples/Example/Hooks/UsePrevious.purs
+++ b/examples/Example/Hooks/UsePrevious.purs
@@ -11,14 +11,14 @@ import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Effect.Ref as Ref
-import Halogen.Hooks (class HookEquals, class HookNewtype, type (<>), Hook, UseEffect, UseRef)
+import Halogen.Hooks (class HookNewtype, type (<>), Hook, UseEffect, UseRef)
 import Halogen.Hooks as Hooks
 
 foreign import data UsePrevious :: Type -> Hooks.HookType
 
 type UsePrevious' a = UseRef (Maybe a) <> UseEffect <> Hooks.Pure
 
-instance newtypeUsePrevious :: HookEquals (UsePrevious' a) h => HookNewtype (UsePrevious a) h
+instance newtypeUsePrevious :: HookNewtype (UsePrevious a) (UsePrevious' a)
 
 usePrevious :: forall m a. MonadAff m => Eq a => a -> Hook m (UsePrevious a) (Maybe a)
 usePrevious value = Hooks.wrap hook

--- a/examples/Example/Hooks/UseWindowWidth.purs
+++ b/examples/Example/Hooks/UseWindowWidth.purs
@@ -11,7 +11,7 @@ import Data.Tuple.Nested ((/\))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Halogen as H
-import Halogen.Hooks (class HookEquals, class HookNewtype, type (<>), Hook, HookM, UseEffect, UseState)
+import Halogen.Hooks (class HookNewtype, type (<>), Hook, HookM, UseEffect, UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Query.Event as HE
 import Web.Event.Event (EventType(..))
@@ -23,7 +23,7 @@ foreign import data UseWindowWidth :: Hooks.HookType
 
 type UseWindowWidth' = UseState (Maybe Int) <> UseEffect <> Hooks.Pure
 
-instance newtypeUseWindowWidth :: HookEquals UseWindowWidth' h => HookNewtype UseWindowWidth h
+instance newtypeUseWindowWidth :: HookNewtype UseWindowWidth UseWindowWidth'
 
 useWindowWidth :: forall m. MonadAff m => Hook m UseWindowWidth (Maybe Int)
 useWindowWidth = Hooks.wrap hook

--- a/examples/Example/Hooks/UseWindowWidth.purs
+++ b/examples/Example/Hooks/UseWindowWidth.purs
@@ -14,10 +14,8 @@ import Halogen as H
 import Halogen.Hooks (class HookEquals, class HookNewtype, type (<>), Hook, HookM, UseEffect, UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Query.Event as HE
-import Unsafe.Coerce (unsafeCoerce)
 import Web.Event.Event (EventType(..))
 import Web.Event.Event as Event
-import Web.Event.EventTarget (EventTarget)
 import Web.HTML as HTML
 import Web.HTML.Window as Window
 
@@ -49,11 +47,7 @@ useWindowWidth = Hooks.wrap hook
         HE.eventListener
           (EventType "resize")
           (Window.toEventTarget window)
-          (Event.target >>> map (fromEventTarget >>> readWidth))
+          (Event.target >=> Window.fromEventTarget >>> map readWidth)
 
       readWidth window
       pure subscriptionId
-
--- This function is missing from the purescript-web-html repository
-fromEventTarget :: EventTarget -> HTML.Window
-fromEventTarget = unsafeCoerce

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210309/packages.dhall sha256:585332a8a11c6420d7287943f81bc2121746cdd352f2cf3f5ecf65053f2afcd3
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210313/packages.dhall sha256:ba6368b31902aad206851fec930e89465440ebf5a1fe0391f8be396e2d2f1d87
 
 let additions =
       { halogen-storybook =

--- a/src/Halogen/Hooks.purs
+++ b/src/Halogen/Hooks.purs
@@ -24,21 +24,22 @@ module Halogen.Hooks
   -- Helpers
   , captures
   , capturesWith
+  , wrap
   )
 where
 
 import Halogen.Hooks.HookM
 
-import Control.Monad.Free (liftF)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\), type (/\))
 import Effect.Ref (Ref)
 import Halogen.Hooks.Component (component, memoComponent)
-import Halogen.Hooks.Hook (class HookNewtype, type (<>), Hook(..), HookAppend, Pure, bind, discard, pure, wrap, HookType)
-import Halogen.Hooks.Internal.Types as IT
+import Halogen.Hooks.Hook (class HookNewtype, type (<>), Hook, HookAppend, Pure, bind, discard, pure)
+import Halogen.Hooks.Hook as Hook
+import Halogen.Hooks.Internal.Types (MemoValue, QueryValue, RefValue, StateValue, fromMemoValue, fromQueryValue, fromRefValue, fromStateValue, toMemoValue, toMemoValues, toMemoValuesImpl, toRefValue, toStateValue)
 import Halogen.Hooks.Internal.UseHookF (UseHookF(..))
-import Halogen.Hooks.Types (ComponentTokens, MemoValues, OutputToken, QueryToken, SlotToken, StateId) -- only export StateId constructor
+import Halogen.Hooks.Types (ComponentTokens, HookType, MemoValues, OutputToken, QueryToken, SlotToken, StateId)
 import Prelude (class Eq, Unit, unit, ($), (<<<), (==))
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -59,13 +60,13 @@ foreign import data UseState :: Type -> HookType
 -- |       Hooks.modify_ stateId \st -> st + 10
 -- | ```
 useState :: forall state m. state -> Hook m (UseState state) (state /\ StateId state)
-useState initialState = Hook $ liftF $ UseState initialState' interface
+useState initialState = Hook.unsafeToHook $ UseState initialState' interface
   where
-  initialState' :: IT.StateValue
-  initialState' = IT.toStateValue initialState
+  initialState' :: StateValue
+  initialState' = toStateValue initialState
 
-  interface :: Tuple IT.StateValue (StateId IT.StateValue) -> Tuple state (StateId state)
-  interface (Tuple value id) = Tuple (IT.fromStateValue value) (unsafeCoerce id)
+  interface :: Tuple StateValue (StateId StateValue) -> Tuple state (StateId state)
+  interface (Tuple value id) = Tuple (fromStateValue value) (unsafeCoerce id)
 
 foreign import data UseEffect :: HookType
 
@@ -75,7 +76,7 @@ foreign import data UseEffect :: HookType
 -- |
 -- | If you would like to run your effect after every render, see `useTickEffect`.
 useLifecycleEffect :: forall m. HookM m (Maybe (HookM m Unit)) -> Hook m UseEffect Unit
-useLifecycleEffect fn = Hook $ liftF $ UseEffect Nothing fn unit
+useLifecycleEffect fn = Hook.unsafeToHook $ UseEffect Nothing fn unit
 
 -- | A Hook providing the ability to run an effect after every render, which
 -- | includes the first time the hook is run.
@@ -99,7 +100,7 @@ useLifecycleEffect fn = Hook $ liftF $ UseEffect Nothing fn unit
 -- |   ...
 -- | ```
 useTickEffect :: forall m. MemoValues -> HookM m (Maybe (HookM m Unit)) -> Hook m UseEffect Unit
-useTickEffect memos fn = Hook $ liftF $ UseEffect (Just memos) fn unit
+useTickEffect memos fn = Hook.unsafeToHook $ UseEffect (Just memos) fn unit
 
 foreign import data UseQuery :: HookType
 
@@ -115,13 +116,13 @@ useQuery
    . QueryToken query
   -> (forall a. query a -> HookM m (Maybe a))
   -> Hook m UseQuery Unit
-useQuery token handler = Hook $ liftF $ UseQuery token' handler' unit
+useQuery token handler = Hook.unsafeToHook $ UseQuery token' handler' unit
   where
-  token' :: QueryToken IT.QueryValue
+  token' :: QueryToken QueryValue
   token' = unsafeCoerce token
 
-  handler' :: forall a. IT.QueryValue a -> HookM m (Maybe a)
-  handler' = handler <<< IT.fromQueryValue
+  handler' :: forall a. QueryValue a -> HookM m (Maybe a)
+  handler' = handler <<< fromQueryValue
 
 foreign import data UseMemo :: Type -> HookType
 
@@ -155,13 +156,13 @@ foreign import data UseMemo :: Type -> HookType
 -- |     expensiveFunction x y
 -- | ```
 useMemo :: forall m a. MemoValues -> (Unit -> a) -> Hook m (UseMemo a) a
-useMemo memos fn = Hook $ liftF $ UseMemo memos to from
+useMemo memos fn = Hook.unsafeToHook $ UseMemo memos to from
   where
-  to :: Unit -> IT.MemoValue
-  to = IT.toMemoValue <<< fn
+  to :: Unit -> MemoValue
+  to = toMemoValue <<< fn
 
-  from :: IT.MemoValue -> a
-  from = IT.fromMemoValue
+  from :: MemoValue -> a
+  from = fromMemoValue
 
 foreign import data UseRef :: Type -> HookType
 
@@ -185,13 +186,13 @@ foreign import data UseRef :: Type -> HookType
 -- | Hooks.pure $ HH.text (show value)
 -- | ```
 useRef :: forall m a. a -> Hook m (UseRef a) (a /\ Ref a)
-useRef initialValue = Hook $ liftF $ UseRef initialValue' interface
+useRef initialValue = Hook.unsafeToHook $ UseRef initialValue' interface
   where
-  initialValue' :: IT.RefValue
-  initialValue' = IT.toRefValue initialValue
+  initialValue' :: RefValue
+  initialValue' = toRefValue initialValue
 
-  interface :: IT.RefValue /\ Ref IT.RefValue -> a /\ Ref a
-  interface (value /\ ref) = IT.fromRefValue value /\ (unsafeCoerce :: Ref IT.RefValue -> Ref a) ref
+  interface :: RefValue /\ Ref RefValue -> a /\ Ref a
+  interface (value /\ ref) = fromRefValue value /\ (unsafeCoerce :: Ref RefValue -> Ref a) ref
 
 -- | Used to improve performance for hooks which may be expensive to run on
 -- | many renders (like `useTickEffect` and `useMemo`). Uses a value equality
@@ -200,7 +201,7 @@ useRef initialValue = Hook $ liftF $ UseRef initialValue' interface
 -- | Some values may be expensive to check for value equality. You can optimize
 -- | this by only checking a sub-part of your captured values using `capturesWith`
 captures :: forall memos a. Eq (Record memos) => Record memos -> (MemoValues -> a) -> a
-captures memos fn = fn $ IT.toMemoValues $ IT.toMemoValuesImpl { eq: (==), memos }
+captures memos fn = fn $ toMemoValues $ toMemoValuesImpl { eq: (==), memos }
 
 -- | Like `captures`, but without an `Eq` constraint. Use when you only want to
 -- | check part of a captured value for equality or when your captured values
@@ -231,4 +232,21 @@ capturesWith
   -> (MemoValues -> a)
   -> a
 capturesWith memosEq memos fn =
-  fn $ IT.toMemoValues $ IT.toMemoValuesImpl { eq: memosEq, memos }
+  fn $ toMemoValues $ toMemoValuesImpl { eq: memosEq, memos }
+
+-- | Make a stack of hooks opaque to improve error messages and ensure internal
+-- | types like state are not leaked outside the module where the hook is defined.
+-- |
+-- | We recommend using this for any custom hooks you define.
+-- |
+-- | ```purs
+-- | foreign import data MyHook :: HookType
+-- |
+-- | instance newtypeMyHook :: HookNewtype MyHook (UseState Int <> Pure)
+-- |
+-- | useMyHook :: forall m. Hook m MyHook Int
+-- | useMyHook = Hooks.wrap Hooks.do
+-- |   ... -- hook definition goes here
+-- | ```
+wrap :: forall h h' m a. HookNewtype h' h => Hook m h a -> Hook m h' a
+wrap = unsafeCoerce -- only necessary because we can't use `Newtype`

--- a/src/Halogen/Hooks.purs
+++ b/src/Halogen/Hooks.purs
@@ -35,7 +35,7 @@ import Data.Tuple (Tuple(..))
 import Data.Tuple.Nested ((/\), type (/\))
 import Effect.Ref (Ref)
 import Halogen.Hooks.Component (component, memoComponent)
-import Halogen.Hooks.Hook (class HookEquals, class HookNewtype, type (<>), Hook(..), HookAppend, Pure, bind, discard, pure, wrap, HookType)
+import Halogen.Hooks.Hook (class HookNewtype, type (<>), Hook(..), HookAppend, Pure, bind, discard, pure, wrap, HookType)
 import Halogen.Hooks.Internal.Types as IT
 import Halogen.Hooks.Internal.UseHookF (UseHookF(..))
 import Halogen.Hooks.Types (ComponentTokens, MemoValues, OutputToken, QueryToken, SlotToken, StateId) -- only export StateId constructor

--- a/src/Halogen/Hooks/Component.purs
+++ b/src/Halogen/Hooks/Component.purs
@@ -9,7 +9,7 @@ import Effect.Ref as Ref
 import Effect.Unsafe (unsafePerformEffect)
 import Halogen as H
 import Halogen.HTML as HH
-import Halogen.Hooks.Hook (Hook(..))
+import Halogen.Hooks.Hook (Hook, unsafeFromHook)
 import Halogen.Hooks.HookM (HookM)
 import Halogen.Hooks.Internal.Eval as Eval
 import Halogen.Hooks.Internal.Eval.Types (HookState(..), toHalogenM)
@@ -112,7 +112,7 @@ memoComponent eqInput inputHookFn = do
       let
         eval = Eval.evalHook Eval.evalHookM evalHook reason stateRef
         { input } = Eval.get stateRef
-        Hook hookF = hookFn input
+        hookF = unsafeFromHook (hookFn input)
 
       a <- H.HalogenM (substFree eval hookF)
 
@@ -125,7 +125,6 @@ memoComponent eqInput inputHookFn = do
     , eval: toHalogenM slotToken outputToken <<< Eval.mkEval eqInput Eval.evalHookM evalHook
     }
   where
-
   initialState input =
     HookState
       { result: HH.text ""

--- a/src/Halogen/Hooks/Types.purs
+++ b/src/Halogen/Hooks/Types.purs
@@ -2,6 +2,15 @@ module Halogen.Hooks.Types where
 
 import Data.Tuple (Tuple)
 
+-- | The kind of types used in Hooks; primitive Hooks already have this kind,
+-- | and Hooks of your own should be foreign imported data types that are also
+-- | types of this kind:
+-- |
+-- | ```purs
+-- | foreign import data UseX :: Hooks.HookType
+-- | ```
+data HookType
+
 -- | A unique identifier for a state produced by `useState`, which can be passed
 -- | to the state functions `get`, `put`, `modify`, and `modify_` to get or
 -- | modify the state.

--- a/test/Test/Hooks/UseMemo.purs
+++ b/test/Test/Hooks/UseMemo.purs
@@ -6,7 +6,7 @@ import Data.Foldable (fold)
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (class HookEquals, class HookNewtype, type (<>), Hook, HookM, UseMemo, UseState)
+import Halogen.Hooks (class HookNewtype, type (<>), Hook, HookM, UseMemo, UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, mkEval, initDriver)
@@ -26,7 +26,7 @@ type UseMemoCount' =
     <> UseMemo Int
     <> Hooks.Pure
 
-instance newtypeUseMemoCount :: HookEquals h UseMemoCount' => HookNewtype UseMemoCount h
+instance newtypeUseMemoCount :: HookNewtype UseMemoCount UseMemoCount'
 
 type Interface =
   { incrementA :: HookM Aff Unit

--- a/test/Test/Integration/Issue5.purs
+++ b/test/Test/Integration/Issue5.purs
@@ -6,7 +6,7 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
 import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.Hooks (class HookEquals, class HookNewtype, type (<>), Hook, UseEffect, UseState)
+import Halogen.Hooks (class HookNewtype, type (<>), Hook, UseEffect, UseState)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
 import Test.Setup.Eval (evalM, initDriver, mkEval)
@@ -25,8 +25,7 @@ type UseTickAfterInitialize' =
     <> UseEffect
     <> Hooks.Pure
 
-instance newtypeUseTickAfterInitialize
-  :: HookEquals h UseTickAfterInitialize' => HookNewtype UseTickAfterInitialize h
+instance newtypeUseTickAfterInitialize :: HookNewtype UseTickAfterInitialize UseTickAfterInitialize'
 
 rerunTickAfterInitialEffects :: LogRef -> Hook Aff UseTickAfterInitialize { count :: Int, state1 :: Int, state2 :: Int }
 rerunTickAfterInitialEffects log = Hooks.wrap Hooks.do

--- a/test/Test/Setup/Eval.purs
+++ b/test/Test/Setup/Eval.purs
@@ -18,7 +18,8 @@ import Halogen as H
 import Halogen.Aff.Driver.Eval as Aff.Driver.Eval
 import Halogen.Aff.Driver.State (DriverState(..), DriverStateX, initDriverState)
 import Halogen.HTML as HH
-import Halogen.Hooks (Hook(..), HookF(..), HookM(..))
+import Halogen.Hooks (Hook, HookF(..), HookM(..))
+import Halogen.Hooks.Hook (unsafeFromHook)
 import Halogen.Hooks.Internal.Eval as Hooks.Eval
 import Halogen.Hooks.Internal.Eval.Types (HalogenM', HookState(..))
 import Halogen.Hooks.Types (ComponentRef, StateId(..))
@@ -119,7 +120,7 @@ mkEvalQuery hookFn =
     let
       eval = Hooks.Eval.evalHook evalHookM evalHook reason stateRef
       { input } = Hooks.Eval.get stateRef
-      Hook hookF = hookFn input
+      hookF = unsafeFromHook (hookFn input)
 
     writeLog (RunHooks reason) input
     a <- H.HalogenM (substFree eval hookF)


### PR DESCRIPTION
This PR finishes the migration to Halogen 6 and PureScript 0.14.

In PureScript 0.14 you can have type synonyms in instance heads. That means the `HookEquals` class is no longer necessary, and so I've removed it. You can now just write `HookNewtype MyHook (UseState Int <> Pure)`, for example.

The `Hook` type takes a phantom parameter of kind `HookType` named `h`. With the new compiler-solved `Coercible` class this means that hooks could be coerced to one another unless the `Hook` newtype's constructor is hidden and the `h` parameter is given an explicit nominal role instead of its inferred phantom role. This PR takes care of the changes necessary to prevent users from coercing hooks to one another.