### PR TITLE
Safer initialization

### DIFF
--- a/test/Test/Integration/Issue73.purs
+++ b/test/Test/Integration/Issue73.purs
@@ -1,0 +1,57 @@
+module Test.Integration.Issue73 where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Effect.Aff (Aff)
+import Halogen (liftAff)
+import Halogen as H
+import Halogen.Hooks (class HookNewtype, type (<>), Hook, UseEffect)
+import Halogen.Hooks as Hooks
+import Halogen.Hooks.Internal.Eval.Types (InterpretHookReason(..))
+import Test.Setup.Eval (evalM, initDriver, mkEval)
+import Test.Setup.Log (getLogRef, logShouldBe, writeLog)
+import Test.Setup.Types (EffectType(..), LogRef, TestEvent(..))
+import Test.Spec (Spec, before, describe, it)
+
+foreign import data UseImmediateRaiseAndReceive :: Hooks.HookType
+
+type UseImmediateRaiseAndReceive' = UseEffect <> Hooks.Pure
+
+instance HookNewtype UseImmediateRaiseAndReceive UseImmediateRaiseAndReceive'
+
+interruptInitialize :: Aff Unit -> LogRef -> Hook Aff UseImmediateRaiseAndReceive Unit
+interruptInitialize interrupt log = Hooks.wrap Hooks.do
+  Hooks.captures { once : true } Hooks.useTickEffect do
+      writeLog (RunEffect (EffectBody 0)) log
+      liftAff interrupt
+      pure $ Just do
+        writeLog (RunEffect (EffectCleanup 0)) log
+
+  Hooks.pure unit
+
+safeInitialize :: Spec Unit
+safeInitialize = before initDriver $ describe "safeInitialize" do
+
+  let
+    -- receive should simulate a parent component firing a Receive to the running hook in response to an action in 
+    -- UseEffect
+    receive ref = do
+      logRef <- getLogRef ref
+      evalM ref $ mkEval ( interruptInitialize $ pure unit ) ( H.Receive logRef )
+
+  it "effect initialization should be safe from interuption by parent" \ref -> do
+    
+    evalM ref $ mkEval ( interruptInitialize $ receive ref ) H.Initialize
+
+    logShouldBe ref initializeSteps
+
+  where
+  initializeSteps =
+    [ RunHooks Initialize -- initialize hooks
+    , Render -- first render occurs
+
+    , RunEffect (EffectBody 0) -- run enqueued lifecycle effect's initializer
+    , RunHooks Step -- get interrupted by parent
+    , Render -- render because of parent
+    ]

--- a/test/Test/Integration/Spec.purs
+++ b/test/Test/Integration/Spec.purs
@@ -3,8 +3,10 @@ module Test.Integration.Spec where
 import Prelude
 
 import Test.Integration.Issue5 (rerunTickAfterInitialEffectsHook)
+import Test.Integration.Issue73 (safeInitialize)
 import Test.Spec (Spec)
 
 spec :: Spec Unit
 spec = do
   rerunTickAfterInitialEffectsHook
+  safeInitialize

--- a/test/Test/Setup/Log.purs
+++ b/test/Test/Setup/Log.purs
@@ -26,6 +26,12 @@ writeLog event ref = liftEffect do
   log <- Ref.read ref
   Ref.write (Array.snoc log event) ref
 
+getLogRef :: forall m r q a. MonadEffect m => Ref (DriverResultState r q a) -> m ( Ref Log )
+getLogRef ref = liftEffect do
+  DriverState driver <- Ref.read ref
+  state <- Ref.read (unwrap driver.state).stateRef
+  pure state.input
+
 readLog :: forall m r q a. MonadEffect m => Ref (DriverResultState r q a) -> m Log
 readLog ref = liftEffect do
   DriverState driver <- Ref.read ref


### PR DESCRIPTION
This PR should fix #73.

I noticed runtime errors when multiple components where mounted together in a render-cycle. Specifically when one ore more components where also raising outputs which would force the parent to render again. When inspecting in the debugger I noticed unsafeGetCell reading an uninitialized effectCells array and crashing.

This fix moves the initialization of the effectCells-array from the Queue-step to the Initialize-step.