### PR TITLE
Hooks.unsubscribe argument corrected to subscriptionId

### DIFF
--- a/docs/07-Hooks-API.md
+++ b/docs/07-Hooks-API.md
@@ -6,12 +6,14 @@ This chapter is still a work in progress, but it contains enough information on 
 
 ## Table of Contents
 
-1. [useState](#usestate)
-2. [useLifecycleEffect](#uselifecycleeffect)
-3. [useTickEffect](#usetickeffect)
-4. [useQuery](#usequery)
-5. [useMemo](#usememo)
-6. [useRef](#useref)
+- [The Hooks API](#the-hooks-api)
+  - [Table of Contents](#table-of-contents)
+  - [useState](#usestate)
+  - [useLifecycleEffect](#uselifecycleeffect)
+  - [useTickEffect](#usetickeffect)
+  - [useQuery](#usequery)
+  - [useMemo](#usememo)
+  - [useRef](#useref)
 
 ## useState
 
@@ -93,7 +95,7 @@ Hooks.do
 
     -- This effect can return another effect to run when these Hooks are removed;
     -- here, we unsubscribe from window resize events.
-    pure $ Just $ Hooks.unsubscribe subscription
+    pure $ Just $ Hooks.unsubscribe subscriptionId
 
   Hooks.pure width
 ```

--- a/docs/07-Hooks-API.md
+++ b/docs/07-Hooks-API.md
@@ -6,14 +6,12 @@ This chapter is still a work in progress, but it contains enough information on 
 
 ## Table of Contents
 
-- [The Hooks API](#the-hooks-api)
-  - [Table of Contents](#table-of-contents)
-  - [useState](#usestate)
-  - [useLifecycleEffect](#uselifecycleeffect)
-  - [useTickEffect](#usetickeffect)
-  - [useQuery](#usequery)
-  - [useMemo](#usememo)
-  - [useRef](#useref)
+1. [useState](#usestate)
+2. [useLifecycleEffect](#uselifecycleeffect)
+3. [useTickEffect](#usetickeffect)
+4. [useQuery](#usequery)
+5. [useMemo](#usememo)
+6. [useRef](#useref)
 
 ## useState
 


### PR DESCRIPTION
Just found this typo in the `useLifecycleEffect` example: Hooks.unsubscribe expects the subscription ID. 